### PR TITLE
fix: correct package.json paths for generated TypeScript files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@kirkdiggler/rpg-api-protos",
   "version": "0.1.0",
   "description": "Protocol Buffer definitions for the RPG API - Generated TypeScript client",
-  "main": "dnd5e/api/v1alpha1/character_pb.js",
-  "types": "dnd5e/api/v1alpha1/character_pb.d.ts",
+  "main": "gen/ts/dnd5e/api/v1alpha1/character_pb.js",
+  "types": "gen/ts/dnd5e/api/v1alpha1/character_pb.d.ts",
   "scripts": {
     "generate": "buf generate",
     "lint": "buf lint",
@@ -32,9 +32,9 @@
     "typescript": "^5.0.0"
   },
   "files": [
-    "dnd5e/**/*.js",
-    "dnd5e/**/*.d.ts",
-    "dnd5e/**/*.ts"
+    "gen/ts/**/*.js",
+    "gen/ts/**/*.d.ts",
+    "gen/ts/**/*.ts"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Fixed package.json paths to match actual generated file locations
- The buf.gen.yaml outputs TypeScript files to `gen/ts/` but package.json was missing this prefix

## Changes
- Updated `main` field from `dnd5e/api/v1alpha1/character_pb.js` to `gen/ts/dnd5e/api/v1alpha1/character_pb.js`
- Updated `types` field to include `gen/ts/` prefix
- Updated `files` array to include `gen/ts/` prefix

## Why this matters
When the CI generates the `generated` branch, it copies this package.json. Without the correct paths, npm packages that depend on this (like rpg-dnd5e-web using `github:KirkDiggler/rpg-api-protos#generated`) can't find the actual generated files.

This fix ensures the generated branch will have a working package.json after the next CI run.