### PR TITLE
feat: use 'latest' branch for generated code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           
           # Create release branch
-          git checkout -B generated
+          git checkout -B latest
           
           # Remove gen/ from gitignore temporarily
           sed '/^gen\/$/d' .gitignore > .gitignore.tmp && mv .gitignore.tmp .gitignore
@@ -138,7 +138,7 @@ jobs:
           git diff --staged --quiet || git commit -m "chore: update generated code and mocks"
           
           # Push release branch
-          git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git generated --force
+          git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git latest --force
       
       - name: Create GitHub release
         if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
## Summary
Simple change: rename the branch where generated code is pushed from `generated` to `latest`.

## Why?
When Go tries to resolve dependencies with `@latest`, it will now find our generated code branch instead of trying to use the main branch (which doesn't have the gen/ folder).

This should fix Connect import issues without any other changes.

## Test Plan
1. Merge this PR
2. CI will push generated code to `latest` branch
3. Try using the proto package with standard Go import (no branch specified)

🤖 Generated with [Claude Code](https://claude.ai/code)