### PR TITLE
Switch from latest to generated branch + add Go proxy retry mechanism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           
           # Create release branch
-          git checkout -B latest
+          git checkout -B generated
           
           # Remove gen/ from gitignore temporarily
           sed '/^gen\/$/d' .gitignore > .gitignore.tmp && mv .gitignore.tmp .gitignore
@@ -139,7 +139,7 @@ jobs:
           git diff --staged --quiet || git commit -m "chore: update generated code and mocks"
           
           # Push release branch
-          git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git latest --force
+          git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git generated --force
           
           # Fetch all tags from origin
           git fetch --tags origin
@@ -152,9 +152,42 @@ jobs:
           echo "Latest tag: $LATEST_TAG"
           echo "New tag: $NEW_TAG"
           
-          # Create and push tag on the latest branch (we're already on it)
+          # Create and push tag on the generated branch (we're already on it)
           git tag -a $NEW_TAG -m "Generated code for $NEW_TAG"
           git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git $NEW_TAG
+          
+          # Export tag for later steps
+          echo "NEW_TAG=$NEW_TAG" >> $GITHUB_ENV
+      
+      # Add this step when implementing connectrc
+      - name: Wait for Go proxy and use connectrc
+        if: false  # Change to true when ready to use
+        run: |
+          echo "Waiting for Go proxy to index $NEW_TAG..."
+          
+          # Retry logic for Go proxy
+          MAX_ATTEMPTS=30
+          SLEEP_TIME=10
+          
+          for i in $(seq 1 $MAX_ATTEMPTS); do
+            echo "Attempt $i/$MAX_ATTEMPTS..."
+            
+            if go list -m github.com/${{ github.repository }}@$NEW_TAG >/dev/null 2>&1; then
+              echo "✓ Module is available in Go proxy!"
+              break
+            fi
+            
+            if [ $i -eq $MAX_ATTEMPTS ]; then
+              echo "❌ Module not available after $MAX_ATTEMPTS attempts"
+              exit 1
+            fi
+            
+            echo "Module not yet available, waiting ${SLEEP_TIME}s..."
+            sleep $SLEEP_TIME
+          done
+          
+          # Now safe to use connectrc
+          # Add your connectrc commands here that do go get github.com/${{ github.repository }}@$NEW_TAG
       
       - name: Create GitHub release
         if: startsWith(github.ref, 'refs/tags/v')

--- a/scripts/wait-for-go-proxy.sh
+++ b/scripts/wait-for-go-proxy.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -e
+
+# Wait for Go proxy to index a module version
+# Usage: ./wait-for-go-proxy.sh <module> <version>
+
+MODULE="${1}"
+VERSION="${2}"
+
+if [ -z "$MODULE" ] || [ -z "$VERSION" ]; then
+    echo "Usage: $0 <module> <version>"
+    echo "Example: $0 github.com/org/repo v1.2.3"
+    exit 1
+fi
+
+echo "Waiting for Go proxy to index ${MODULE}@${VERSION}..."
+
+# Configuration
+MAX_ATTEMPTS=${GO_PROXY_MAX_ATTEMPTS:-30}
+SLEEP_TIME=${GO_PROXY_SLEEP_TIME:-10}
+
+# Function to check if module is available
+check_module() {
+    go list -m "${MODULE}@${VERSION}" >/dev/null 2>&1
+}
+
+# Retry logic
+for i in $(seq 1 $MAX_ATTEMPTS); do
+    echo "Attempt $i/$MAX_ATTEMPTS..."
+    
+    if check_module; then
+        echo "✓ Module ${MODULE}@${VERSION} is available!"
+        exit 0
+    fi
+    
+    if [ $i -eq $MAX_ATTEMPTS ]; then
+        echo "❌ Module not available after $MAX_ATTEMPTS attempts"
+        exit 1
+    fi
+    
+    echo "Module not yet available, waiting ${SLEEP_TIME}s..."
+    sleep $SLEEP_TIME
+done


### PR DESCRIPTION
## Summary
- Switch release branch from `latest` to `generated` for better clarity
- Add retry mechanism for future connectrc integration (currently disabled)
- Add reusable retry script for Go proxy delays

## Changes
1. **Branch rename**: All references to `latest` branch changed to `generated`
2. **Retry mechanism**: Added workflow step to wait for Go proxy indexing (set to `if: false` to keep current behavior)
3. **Helper script**: Added `scripts/wait-for-go-proxy.sh` for reusable retry logic
4. **Environment export**: Export `NEW_TAG` for use in subsequent workflow steps

## Test plan
- [x] Workflow continues to work as before (retry is disabled)
- [ ] On merge, workflow will create tags on `generated` branch instead of `latest`
- [ ] Future PR can enable retry by changing `if: false` to `if: true`

## Next steps
After this merges, we can add connectrc support in a follow-up PR and enable the retry mechanism.

🤖 Generated with [Claude Code](https://claude.ai/code)