### PR TITLE
Add dice rolling messages for character creation

### DIFF
--- a/dnd5e/api/v1alpha1/character.proto
+++ b/dnd5e/api/v1alpha1/character.proto
@@ -40,6 +40,9 @@ service CharacterService {
   rpc GetRaceDetails(GetRaceDetailsRequest) returns (GetRaceDetailsResponse);
   rpc GetClassDetails(GetClassDetailsRequest) returns (GetClassDetailsResponse);
   rpc GetBackgroundDetails(GetBackgroundDetailsRequest) returns (GetBackgroundDetailsResponse);
+
+  // Dice rolling for character creation
+  rpc RollAbilityScores(RollAbilityScoresRequest) returns (RollAbilityScoresResponse);
 }
 
 // Ability scores for a character
@@ -382,7 +385,15 @@ message UpdateBackgroundRequest {
 
 message UpdateAbilityScoresRequest {
   string draft_id = 1;
-  AbilityScores ability_scores = 2;
+  
+  // Choose how to set ability scores
+  oneof scores_input {
+    // Manually set ability scores
+    AbilityScores ability_scores = 2;
+    
+    // Assign rolled dice to abilities
+    RollAssignments roll_assignments = 3;
+  }
 }
 
 message UpdateSkillsRequest {
@@ -712,4 +723,48 @@ message GetBackgroundDetailsRequest {
 // Response with detailed background information
 message GetBackgroundDetailsResponse {
   BackgroundInfo background = 1;
+}
+
+// Dice rolling messages for ability scores
+
+// Request to roll ability scores for a character draft
+message RollAbilityScoresRequest {
+  string draft_id = 1;
+}
+
+// A single ability score roll (4d6 drop lowest)
+message AbilityScoreRoll {
+  // Unique identifier for this roll (roll_1, roll_2, etc.)
+  string roll_id = 1;
+  
+  // The individual dice that were rolled (4 dice)
+  repeated int32 dice = 2;
+  
+  // The sum of the highest 3 dice (final ability score value)
+  int32 total = 3;
+  
+  // The dice value that was dropped (lowest)
+  int32 dropped = 4;
+  
+  // Human readable notation (e.g., "4d6 drop lowest: [6,5,4,1] = 15")
+  string notation = 5;
+}
+
+// Response containing 6 ability score rolls
+message RollAbilityScoresResponse {
+  // Array of 6 rolls that can be assigned to abilities
+  repeated AbilityScoreRoll rolls = 1;
+  
+  // Unix timestamp when these rolls expire (15 minutes from creation)
+  int64 expires_at = 2;
+}
+
+// Roll assignment mapping for ability scores
+message RollAssignments {
+  string strength_roll_id = 1;
+  string dexterity_roll_id = 2;
+  string constitution_roll_id = 3;
+  string intelligence_roll_id = 4;
+  string wisdom_roll_id = 5;
+  string charisma_roll_id = 6;
 }

--- a/docs/adr/001-dice-service-architecture.md
+++ b/docs/adr/001-dice-service-architecture.md
@@ -1,0 +1,226 @@
+# ADR-001: Dice Service Architecture - Generic Service with Entity+Context Grouping
+
+**Status**: Proposed  
+**Date**: 2025-07-16  
+**Decision-makers**: Kirk Diggler, Claude AI  
+**Technical story**: [Issue #57](https://github.com/KirkDiggler/rpg-api/issues/57) - Add RollAbilityScores RPC with roll IDs and flexible assignment
+
+## Summary
+
+We need to add dice rolling functionality to support D&D 5e character creation (ability scores). The key decision is whether to create a generic `DiceService` or embed dice rolling within the `CharacterService`.
+
+## Problem Statement
+
+### Immediate Need
+- D&D 5e character creation requires rolling 6 sets of 4d6 (drop lowest)
+- Rolls need persistent IDs for flexible assignment (str=roll_3, dex=roll_1, etc.)
+- Roll sessions need 15-minute expiration
+- Security: prevent players from using other players' rolls
+
+### Long-term Vision
+- SDK will support multiple RPG systems (D&D 5e, Pathfinder, GURPS, etc.)
+- Combat system will need dice rolling for attacks, damage, saves
+- Generic dice mechanics should be reusable across systems
+- Monster/NPC generation will need dice rolling
+- Future: dice rolling for skill checks, random encounters, etc.
+
+## Decision
+
+**We will create a separate `DiceService` as a generic gRPC service alongside the D&D 5e `CharacterService`.**
+
+### Core Design Principles
+
+1. **Generic DiceService**: Universal dice mechanics for all RPG systems
+2. **Entity+Context Grouping**: Rolls organized by `entity_id` + `context`
+3. **Separate gRPC Services**: Clean API boundaries for SDK users
+4. **Internal Orchestrator Sharing**: Avoid code duplication internally
+
+### Service Architecture
+
+```
+External API (gRPC Services)
+┌─────────────────┐     ┌─────────────────┐
+│   DiceService   │     │ CharacterService│
+│    (generic)    │     │   (D&D 5e)      │
+└─────────────────┘     └─────────────────┘
+         │                        │
+         └────────┬─────────────────┘
+                  │
+         ┌─────────────────┐
+         │ Internal Layer  │
+         │ ┌─────────────┐ │
+         │ │DiceOrch     │ │  ← Shared internally
+         │ │(business)   │ │
+         │ └─────────────┘ │
+         └─────────────────┘
+```
+
+### Storage Pattern
+
+**Key Format**: `dice_session:{entity_id}:{context}`
+
+**Examples**:
+- `dice_session:char_draft_123:ability_scores` - Character creation rolls
+- `dice_session:char_789:combat_round_1` - Combat rolls
+- `dice_session:monster_456:damage_rolls` - Monster damage
+- `dice_session:party_123:initiative` - Party initiative
+
+### API Design
+
+```protobuf
+// api/v1alpha1/dice.proto
+service DiceService {
+  rpc RollDice(RollDiceRequest) returns (RollDiceResponse);
+  rpc GetRollSession(GetRollSessionRequest) returns (GetRollSessionResponse);
+  rpc ClearRollSession(ClearRollSessionRequest) returns (ClearRollSessionResponse);
+}
+
+// dnd5e/api/v1alpha1/character.proto
+service CharacterService {
+  rpc RollAbilityScores(RollAbilityScoresRequest) returns (RollAbilityScoresResponse);
+  rpc UpdateAbilityScores(UpdateAbilityScoresRequest) returns (UpdateAbilityScoresResponse);
+}
+```
+
+## Alternatives Considered
+
+### Alternative 1: Dice Rolling in CharacterService Only
+```protobuf
+service CharacterService {
+  rpc RollAbilityScores(RollAbilityScoresRequest) returns (RollAbilityScoresResponse);
+}
+```
+
+**Pros**:
+- Simpler initial implementation
+- All character logic in one service
+- No inter-service communication
+
+**Cons**:
+- Not reusable for combat system
+- Combat dice rolling would need separate implementation
+- SDK users need multiple services for dice functionality
+- Violates DRY principle for dice mechanics
+- Other RPG systems would duplicate dice logic
+
+### Alternative 2: Pure Generic DiceService (No CharacterService dice methods)
+```protobuf
+service DiceService {
+  rpc RollDice(RollDiceRequest) returns (RollDiceResponse);
+}
+// Character service has no dice methods
+```
+
+**Pros**:
+- Maximum reusability
+- Clean separation of concerns
+- Single source of truth for dice
+
+**Cons**:
+- Character creation UX becomes complex
+- Clients need to understand D&D 5e rules (4d6 drop lowest)
+- No validation of ability score assignment
+- Security model more complex
+
+### Alternative 3: Dice Service with Session Management Only
+```protobuf
+service DiceService {
+  rpc CreateRollSession(CreateRollSessionRequest) returns (CreateRollSessionResponse);
+  rpc AddRollToSession(AddRollToSessionRequest) returns (AddRollToSessionResponse);
+}
+```
+
+**Pros**:
+- Explicit session management
+- Clear ownership model
+
+**Cons**:
+- More complex API
+- Additional round trips for multiple rolls
+- Session lifecycle management complexity
+
+## Rationale
+
+### Why Generic DiceService?
+
+1. **SDK Vision**: Our long-term goal is an SDK supporting multiple RPG systems
+2. **Reusability**: Combat, skill checks, random generation all need dice
+3. **Clean Architecture**: Dice mechanics are orthogonal to character creation
+4. **Future-Proof**: Easy to add new notation, roll types, mechanics
+
+### Why Entity+Context Grouping?
+
+1. **Security**: Rolls tied to specific entities prevent cross-contamination
+2. **Organization**: Related rolls grouped together (combat round, ability scores)
+3. **TTL Management**: Each context can have different expiration times
+4. **Atomic Operations**: Can clear entire contexts when done
+
+### Why Separate gRPC Services?
+
+1. **SDK Flexibility**: Clients can use just dice service for combat
+2. **Service Boundaries**: Clear separation of concerns in API
+3. **Independent Evolution**: Services can evolve independently
+4. **Client Choice**: Use character service for UX, dice service for mechanics
+
+## Implementation Strategy
+
+### Phase 1: Core Infrastructure
+1. Create `api/v1alpha1/dice.proto` with generic service
+2. Implement `DiceOrchestrator` with entity+context storage
+3. Add Redis storage with TTL support
+
+### Phase 2: Character Integration
+1. Update `dnd5e/api/v1alpha1/character.proto` with ability rolling
+2. Implement `CharacterService.RollAbilityScores()` using `DiceOrchestrator`
+3. Add roll assignment validation
+
+### Phase 3: SDK Integration
+1. Generate clients for both services
+2. Create SDK helpers for common patterns
+3. Add TypeScript/Go examples
+
+## Consequences
+
+### Positive
+- **Reusable**: Dice service works for any RPG system
+- **Scalable**: Easy to add new dice mechanics
+- **Clean**: Clear separation between generic and specific logic
+- **SDK-Ready**: Multiple services provide client flexibility
+- **Future-Proof**: Easy to extend for combat, skill checks, etc.
+
+### Negative
+- **Complexity**: Two services instead of one
+- **Coordination**: Character service must coordinate with dice service
+- **Testing**: More integration testing between services
+- **Documentation**: Need to document both services
+
+### Neutral
+- **Performance**: Minimal impact (internal orchestrator sharing)
+- **Deployment**: Both services in same binary initially
+
+## Validation
+
+### Success Criteria
+1. **Functional**: D&D 5e character creation works with roll assignment
+2. **Reusable**: Combat system can use dice service for attack rolls
+3. **Secure**: Players cannot use other players' rolls
+4. **SDK**: TypeScript/Go clients work independently
+5. **Performance**: Roll operations complete in <100ms
+
+### Monitoring
+- Roll session creation/expiration rates
+- Service boundary performance
+- Client usage patterns (which services used together)
+
+## Related Decisions
+
+- **[ADR-002]**: Will define storage patterns for dice sessions
+- **[ADR-003]**: Will define SDK client patterns
+- **Future**: Combat system integration with dice service
+
+## References
+
+- [Issue #57](https://github.com/KirkDiggler/rpg-api/issues/57) - Add RollAbilityScores RPC
+- [Issue #58](https://github.com/KirkDiggler/rpg-api/issues/58) - Redis storage for roll sessions
+- [Issue #59](https://github.com/KirkDiggler/rpg-api/issues/59) - Proto updates for dice rolling
+- [D&D 5e Ability Score Generation Rules](https://www.dndbeyond.com/sources/basic-rules/step-by-step-characters#DetermineAbilityScores)


### PR DESCRIPTION
## Summary
Implements Issue #59: Update rpg-api-protos with dice rolling messages

Adds support for D&D 5e ability score rolling with flexible assignment per ADR-001.

## Changes
- ✅ Add `RollAbilityScoresRequest/Response` messages
- ✅ Add `AbilityScoreRoll` message with roll details (4d6 drop lowest) 
- ✅ Add `RollAssignments` message for flexible ability assignment
- ✅ Enhance `UpdateAbilityScoresRequest` with oneof for manual vs rolled scores
- ✅ Add `RollAbilityScores` RPC to CharacterService
- ✅ Include ADR-001 documentation

## Message Structure
- **AbilityScoreRoll**: Individual roll with ID, dice values, total, dropped die
- **RollAbilityScoresResponse**: 6 rolls with 15-minute expiration timestamp  
- **RollAssignments**: Map roll IDs to specific abilities (str=roll_3, etc.)
- **UpdateAbilityScoresRequest**: Support both manual scores and roll assignments

## Generated Code
- ✅ Go: character.pb.go, character_grpc.pb.go, character.connect.go
- ✅ TypeScript: character_pb.ts, character_connect.ts
- ✅ Proto compilation successful with `buf generate`

## Testing
- [x] Proto compiles without errors
- [x] Generated Go code includes new messages and oneof handling
- [x] Generated TypeScript code includes new messages

## Next Steps
After merge to `generated` branch, rpg-api can update dependency with:
```bash
go get github.com/KirkDiggler/rpg-api-protos/gen/go@generated
```

Enables implementation of Issues #57, #58, #60 for dice service architecture.

🤖 Generated with [Claude Code](https://claude.ai/code)