### PR TITLE
Feat/add generic dice service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
           # Generate mocks for gRPC services
           mkdir -p gen/go/clients/dnd5e/api/v1alpha1/mocks
           mockgen -source=gen/go/clients/dnd5e/api/v1alpha1/character_grpc.pb.go -destination=gen/go/clients/dnd5e/api/v1alpha1/mocks/character_service.go -package=mocks
+          mkdir -p gen/go/clients/api/v1alpha1/mocks
+          mockgen -source=gen/go/clients/api/v1alpha1/dice_grpc.pb.go -destination=gen/go/clients/api/v1alpha1/mocks/dice_service.go -package=mocks
       
       - name: Verify Go generation
         run: |
@@ -112,6 +114,8 @@ jobs:
           buf generate
           mkdir -p gen/go/clients/dnd5e/api/v1alpha1/mocks
           mockgen -source=gen/go/clients/dnd5e/api/v1alpha1/character_grpc.pb.go -destination=gen/go/clients/dnd5e/api/v1alpha1/mocks/character_service.go -package=mocks
+          mkdir -p gen/go/clients/api/v1alpha1/mocks
+          mockgen -source=gen/go/clients/api/v1alpha1/dice_grpc.pb.go -destination=gen/go/clients/api/v1alpha1/mocks/dice_service.go -package=mocks
       
       - name: Setup Go module
         run: |

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,10 @@ test: ## Run tests (lint + format check + generate + mocks)
 	$(MAKE) mocks
 
 mocks: ## Generate mocks for gRPC services
-	mkdir -p gen/go/github.com/KirkDiggler/rpg-api-protos/clients/dnd5e/api/v1alpha1/mocks
-	mockgen -source=gen/go/github.com/KirkDiggler/rpg-api-protos/clients/dnd5e/api/v1alpha1/character_grpc.pb.go -destination=gen/go/github.com/KirkDiggler/rpg-api-protos/clients/dnd5e/api/v1alpha1/mocks/character_service.go -package=mocks
-	mkdir -p gen/go/github.com/KirkDiggler/rpg-api-protos/clients/api/v1alpha1/mocks
-	mockgen -source=gen/go/clients/api/v1alpha1/dice_grpc.pb.go -destination=gen/go/github.com/KirkDiggler/rpg-api-protos/clients/api/v1alpha1/mocks/dice_service.go -package=mocks
+	mkdir -p gen/go/clients/dnd5e/api/v1alpha1/mocks
+	mockgen -source=gen/go/clients/dnd5e/api/v1alpha1/character_grpc.pb.go -destination=gen/go/clients/dnd5e/api/v1alpha1/mocks/character_service.go -package=mocks
+	mkdir -p gen/go/clients/api/v1alpha1/mocks
+	mockgen -source=gen/go/clients/api/v1alpha1/dice_grpc.pb.go -destination=gen/go/clients/api/v1alpha1/mocks/dice_service.go -package=mocks
 
 breaking: ## Check for breaking changes against main branch
 	buf breaking --against '.git#branch=main'

--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,13 @@ test: ## Run tests (lint + format check + generate + mocks)
 	buf lint
 	buf format --diff --exit-code
 	buf generate
-	mkdir -p gen/go/github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha1/mocks
-	mockgen -source=gen/go/github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha1/character_grpc.pb.go -destination=gen/go/github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha1/mocks/character_service.go -package=mocks
+	$(MAKE) mocks
 
 mocks: ## Generate mocks for gRPC services
-	mkdir -p gen/go/github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha1/mocks
-	mockgen -source=gen/go/github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha1/character_grpc.pb.go -destination=gen/go/github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha1/mocks/character_service.go -package=mocks
+	mkdir -p gen/go/github.com/KirkDiggler/rpg-api-protos/clients/dnd5e/api/v1alpha1/mocks
+	mockgen -source=gen/go/github.com/KirkDiggler/rpg-api-protos/clients/dnd5e/api/v1alpha1/character_grpc.pb.go -destination=gen/go/github.com/KirkDiggler/rpg-api-protos/clients/dnd5e/api/v1alpha1/mocks/character_service.go -package=mocks
+	mkdir -p gen/go/github.com/KirkDiggler/rpg-api-protos/clients/api/v1alpha1/mocks
+	mockgen -source=gen/go/clients/api/v1alpha1/dice_grpc.pb.go -destination=gen/go/github.com/KirkDiggler/rpg-api-protos/clients/api/v1alpha1/mocks/dice_service.go -package=mocks
 
 breaking: ## Check for breaking changes against main branch
 	buf breaking --against '.git#branch=main'

--- a/api/v1alpha1/dice.proto
+++ b/api/v1alpha1/dice.proto
@@ -110,4 +110,3 @@ message ClearRollSessionResponse {
   // Number of rolls that were cleared
   int32 rolls_cleared = 2;
 }
-

--- a/api/v1alpha1/dice.proto
+++ b/api/v1alpha1/dice.proto
@@ -1,0 +1,112 @@
+syntax = "proto3";
+
+package api.v1alpha1;
+
+// Generic dice service for all RPG systems
+// Provides universal dice mechanics with entity+context grouping
+service DiceService {
+  // Roll dice and store in a session
+  rpc RollDice(RollDiceRequest) returns (RollDiceResponse);
+  
+  // Get existing roll session
+  rpc GetRollSession(GetRollSessionRequest) returns (GetRollSessionResponse);
+  
+  // Clear a roll session
+  rpc ClearRollSession(ClearRollSessionRequest) returns (ClearRollSessionResponse);
+}
+
+// Request to roll dice
+message RollDiceRequest {
+  // Entity that owns these rolls (e.g., "char_draft_123", "char_789", "monster_456")
+  string entity_id = 1;
+  
+  // Context for grouping related rolls (e.g., "ability_scores", "combat_round_1", "damage_rolls")
+  string context = 2;
+  
+  // Dice notation to roll (e.g., "4d6", "1d20", "2d8+3")
+  string notation = 3;
+  
+  // Number of separate rolls to make (default 1)
+  int32 count = 4;
+  
+  // TTL in seconds for this roll session (default 900 = 15 minutes)
+  int32 ttl_seconds = 5;
+  
+  // Optional modifier description for display
+  string modifier_description = 6;
+}
+
+// Response with dice roll results
+message RollDiceResponse {
+  // The rolls that were generated
+  repeated DiceRoll rolls = 1;
+  
+  // When this roll session expires (Unix timestamp)
+  int64 expires_at = 2;
+}
+
+// A single dice roll result
+message DiceRoll {
+  // Unique identifier for this roll within the session
+  string roll_id = 1;
+  
+  // Dice notation that was rolled
+  string notation = 2;
+  
+  // Individual dice values that were rolled
+  repeated int32 dice = 3;
+  
+  // Final result after applying modifiers
+  int32 total = 4;
+  
+  // Any dice that were dropped (for "drop lowest" etc.)
+  repeated int32 dropped = 5;
+  
+  // Human-readable description of the roll
+  string description = 6;
+  
+  // Raw dice total before modifiers
+  int32 dice_total = 7;
+  
+  // Modifier applied to get final total
+  int32 modifier = 8;
+}
+
+// Request to get an existing roll session
+message GetRollSessionRequest {
+  // Entity that owns the rolls
+  string entity_id = 1;
+  
+  // Context to retrieve
+  string context = 2;
+}
+
+// Response with roll session data
+message GetRollSessionResponse {
+  // The rolls in this session
+  repeated DiceRoll rolls = 1;
+  
+  // When this session expires (Unix timestamp)
+  int64 expires_at = 2;
+  
+  // When this session was created (Unix timestamp)
+  int64 created_at = 3;
+}
+
+// Request to clear a roll session
+message ClearRollSessionRequest {
+  // Entity that owns the rolls
+  string entity_id = 1;
+  
+  // Context to clear
+  string context = 2;
+}
+
+// Response from clearing a roll session
+message ClearRollSessionResponse {
+  // Confirmation message
+  string message = 1;
+  
+  // Number of rolls that were cleared
+  int32 rolls_cleared = 2;
+}

--- a/api/v1alpha1/dice.proto
+++ b/api/v1alpha1/dice.proto
@@ -7,10 +7,10 @@ package api.v1alpha1;
 service DiceService {
   // Roll dice and store in a session
   rpc RollDice(RollDiceRequest) returns (RollDiceResponse);
-  
+
   // Get existing roll session
   rpc GetRollSession(GetRollSessionRequest) returns (GetRollSessionResponse);
-  
+
   // Clear a roll session
   rpc ClearRollSession(ClearRollSessionRequest) returns (ClearRollSessionResponse);
 }
@@ -19,19 +19,19 @@ service DiceService {
 message RollDiceRequest {
   // Entity that owns these rolls (e.g., "char_draft_123", "char_789", "monster_456")
   string entity_id = 1;
-  
+
   // Context for grouping related rolls (e.g., "ability_scores", "combat_round_1", "damage_rolls")
   string context = 2;
-  
+
   // Dice notation to roll (e.g., "4d6", "1d20", "2d8+3")
   string notation = 3;
-  
+
   // Number of separate rolls to make (default 1)
   int32 count = 4;
-  
+
   // TTL in seconds for this roll session (default 900 = 15 minutes)
   int32 ttl_seconds = 5;
-  
+
   // Optional modifier description for display
   string modifier_description = 6;
 }
@@ -40,7 +40,7 @@ message RollDiceRequest {
 message RollDiceResponse {
   // The rolls that were generated
   repeated DiceRoll rolls = 1;
-  
+
   // When this roll session expires (Unix timestamp)
   int64 expires_at = 2;
 }
@@ -49,25 +49,25 @@ message RollDiceResponse {
 message DiceRoll {
   // Unique identifier for this roll within the session
   string roll_id = 1;
-  
+
   // Dice notation that was rolled
   string notation = 2;
-  
+
   // Individual dice values that were rolled
   repeated int32 dice = 3;
-  
+
   // Final result after applying modifiers
   int32 total = 4;
-  
+
   // Any dice that were dropped (for "drop lowest" etc.)
   repeated int32 dropped = 5;
-  
+
   // Human-readable description of the roll
   string description = 6;
-  
+
   // Raw dice total before modifiers
   int32 dice_total = 7;
-  
+
   // Modifier applied to get final total
   int32 modifier = 8;
 }
@@ -76,7 +76,7 @@ message DiceRoll {
 message GetRollSessionRequest {
   // Entity that owns the rolls
   string entity_id = 1;
-  
+
   // Context to retrieve
   string context = 2;
 }
@@ -85,10 +85,10 @@ message GetRollSessionRequest {
 message GetRollSessionResponse {
   // The rolls in this session
   repeated DiceRoll rolls = 1;
-  
+
   // When this session expires (Unix timestamp)
   int64 expires_at = 2;
-  
+
   // When this session was created (Unix timestamp)
   int64 created_at = 3;
 }
@@ -97,7 +97,7 @@ message GetRollSessionResponse {
 message ClearRollSessionRequest {
   // Entity that owns the rolls
   string entity_id = 1;
-  
+
   // Context to clear
   string context = 2;
 }
@@ -106,7 +106,8 @@ message ClearRollSessionRequest {
 message ClearRollSessionResponse {
   // Confirmation message
   string message = 1;
-  
+
   // Number of rolls that were cleared
   int32 rolls_cleared = 2;
 }
+


### PR DESCRIPTION
This pull request introduces a new `DiceService` for handling dice mechanics in RPG systems, along with updates to the workflow and Makefile to integrate mock generation for the new service. The most important changes include the addition of the `DiceService` definition, updates to automate mock generation, and refactoring in the `Makefile`.

### New Feature: DiceService

* [`api/v1alpha1/dice.proto`](diffhunk://#diff-d2a6f4790a81f035bc785c70ca977b12cfd6083de3debd5b3c757fb0c0b2d781R1-R112): Added a new `DiceService` with methods for rolling dice, retrieving roll sessions, and clearing roll sessions. Includes detailed request and response message definitions for handling dice mechanics.

### Workflow Updates

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR63-R64): Updated the CI workflow to generate mocks for the new `DiceService` by adding mock generation commands for `dice_grpc.pb.go`. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR63-R64) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR117-R118)

### Build System Refactor

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L31-R37): Refactored the `Makefile` to centralize mock generation into a dedicated `mocks` target, which now includes mock generation for the new `DiceService`. Updated paths to align with the new structure.