### PR TITLE
Add GetFeature endpoint with programmatic spell selection data

### DIFF
--- a/dnd5e/api/v1alpha1/character.proto
+++ b/dnd5e/api/v1alpha1/character.proto
@@ -694,17 +694,26 @@ message FeatureInfo {
   string class_name = 5;
   repeated Choice choices = 6;
   bool has_choices = 7;
+  // Contains spell selection requirements for features that involve spell selection.
+  // This field is only populated for features that allow or require selecting spells.
   SpellSelectionInfo spell_selection = 8;
 }
 
 // Programmatic spell selection requirements
 message SpellSelectionInfo {
   int32 spells_to_select = 1;     // Number of spells to select
-  int32 spell_level = 2;          // Required spell level (0 for cantrips)
-  repeated int32 spell_levels = 3; // Multiple allowed spell levels
-  repeated string spell_lists = 4; // Allowed spell lists (e.g., "wizard", "cleric")
-  string selection_type = 5;      // "spellbook", "known", "prepared"
-  bool requires_replace = 6;      // Whether spells can be replaced on level up
+  repeated int32 spell_levels = 2; // Allowed spell levels (0 for cantrips)
+  repeated string spell_lists = 3; // Allowed spell lists (e.g., "wizard", "cleric")
+  SpellSelectionType selection_type = 4; // Type of spell selection system
+  bool requires_replace = 5;      // Whether spells can be replaced on level up
+}
+
+// Types of spell selection systems
+enum SpellSelectionType {
+  SPELL_SELECTION_TYPE_UNSPECIFIED = 0;
+  SPELL_SELECTION_TYPE_SPELLBOOK = 1;   // Wizard spellbook system
+  SPELL_SELECTION_TYPE_KNOWN = 2;       // Fixed known spells (sorcerer, warlock)
+  SPELL_SELECTION_TYPE_PREPARED = 3;    // Prepared spells (cleric, druid)
 }
 
 // Request to list races

--- a/dnd5e/api/v1alpha1/character.proto
+++ b/dnd5e/api/v1alpha1/character.proto
@@ -40,6 +40,7 @@ service CharacterService {
   rpc GetRaceDetails(GetRaceDetailsRequest) returns (GetRaceDetailsResponse);
   rpc GetClassDetails(GetClassDetailsRequest) returns (GetClassDetailsResponse);
   rpc GetBackgroundDetails(GetBackgroundDetailsRequest) returns (GetBackgroundDetailsResponse);
+  rpc GetFeature(GetFeatureRequest) returns (GetFeatureResponse);
 
   // Dice rolling for character creation
   rpc RollAbilityScores(RollAbilityScoresRequest) returns (RollAbilityScoresResponse);
@@ -685,6 +686,28 @@ message BackgroundInfo {
   repeated string flaws = 15;
 }
 
+// Detailed feature information for class features, racial traits, etc.
+message FeatureInfo {
+  string id = 1;
+  string name = 2;
+  string description = 3;
+  int32 level = 4;
+  string class_name = 5;
+  repeated Choice choices = 6;
+  bool has_choices = 7;
+  SpellSelectionInfo spell_selection = 8;
+}
+
+// Programmatic spell selection requirements
+message SpellSelectionInfo {
+  int32 spells_to_select = 1;     // Number of spells to select
+  int32 spell_level = 2;          // Required spell level (0 for cantrips)
+  repeated int32 spell_levels = 3; // Multiple allowed spell levels
+  repeated string spell_lists = 4; // Allowed spell lists (e.g., "wizard", "cleric")
+  string selection_type = 5;      // "spellbook", "known", "prepared"
+  bool requires_replace = 6;      // Whether spells can be replaced on level up
+}
+
 // Request to list races
 message ListRacesRequest {
   // Pagination
@@ -762,6 +785,16 @@ message GetBackgroundDetailsRequest {
 // Response with detailed background information
 message GetBackgroundDetailsResponse {
   BackgroundInfo background = 1;
+}
+
+// Request for a specific feature by its ID
+message GetFeatureRequest {
+  string feature_id = 1;
+}
+
+// Response with detailed feature information
+message GetFeatureResponse {
+  FeatureInfo feature = 1;
 }
 
 // Dice rolling messages for ability scores

--- a/dnd5e/api/v1alpha1/character.proto
+++ b/dnd5e/api/v1alpha1/character.proto
@@ -701,19 +701,19 @@ message FeatureInfo {
 
 // Programmatic spell selection requirements
 message SpellSelectionInfo {
-  int32 spells_to_select = 1;     // Number of spells to select
+  int32 spells_to_select = 1; // Number of spells to select
   repeated int32 spell_levels = 2; // Allowed spell levels (0 for cantrips)
   repeated string spell_lists = 3; // Allowed spell lists (e.g., "wizard", "cleric")
   SpellSelectionType selection_type = 4; // Type of spell selection system
-  bool requires_replace = 5;      // Whether spells can be replaced on level up
+  bool requires_replace = 5; // Whether spells can be replaced on level up
 }
 
 // Types of spell selection systems
 enum SpellSelectionType {
   SPELL_SELECTION_TYPE_UNSPECIFIED = 0;
-  SPELL_SELECTION_TYPE_SPELLBOOK = 1;   // Wizard spellbook system
-  SPELL_SELECTION_TYPE_KNOWN = 2;       // Fixed known spells (sorcerer, warlock)
-  SPELL_SELECTION_TYPE_PREPARED = 3;    // Prepared spells (cleric, druid)
+  SPELL_SELECTION_TYPE_SPELLBOOK = 1; // Wizard spellbook system
+  SPELL_SELECTION_TYPE_KNOWN = 2; // Fixed known spells (sorcerer, warlock)
+  SPELL_SELECTION_TYPE_PREPARED = 3; // Prepared spells (cleric, druid)
 }
 
 // Request to list races

--- a/dnd5e/api/v1alpha1/character.proto
+++ b/dnd5e/api/v1alpha1/character.proto
@@ -621,7 +621,7 @@ message ClassInfo {
   repeated EquipmentChoice equipment_choices = 13;
 
   // Class features at level 1
-  repeated ClassFeature level_1_features = 14;
+  repeated FeatureInfo level_1_features = 14;
 
   // Spellcasting information (if applicable)
   SpellcastingInfo spellcasting = 15;
@@ -637,16 +637,15 @@ message EquipmentChoice {
   int32 choose_count = 3;
 }
 
-// Class feature description
-message ClassFeature {
-  string name = 1;
-  string description = 2;
-  int32 level = 3;
-
-  // Whether this feature has choices
-  bool has_choices = 4;
-  repeated string choices = 5;
-}
+// Deprecated: Use FeatureInfo instead for richer feature data
+// message ClassFeature {
+//   string name = 1;
+//   string description = 2;
+//   int32 level = 3;
+//   // Whether this feature has choices
+//   bool has_choices = 4;
+//   repeated string choices = 5;
+// }
 
 // Spellcasting information
 message SpellcastingInfo {


### PR DESCRIPTION
## Summary
- Add GetFeature RPC method to fetch detailed feature information
- Add FeatureInfo message with comprehensive feature data
- Add SpellSelectionInfo message with programmatic spell selection requirements

## Features Added
- **GetFeature endpoint**: Fetch detailed information about class features, racial traits, etc.
- **Programmatic spell limits**: Structured data for spell selection (wizard gets 6 spells, etc.)
- **Selection types**: Support for "spellbook", "known", and "prepared" spell systems
- **Spell list constraints**: Specify which spell lists are allowed (wizard, cleric, etc.)

## Use Cases
- **Wizard spellbook**: App can programmatically know to select 6 level-1 wizard spells
- **Spellcasting classes**: Each class provides exact spell selection requirements
- **Character creation**: UI can dynamically generate spell selection interfaces

## Test Plan
- [ ] Proto compilation passes
- [ ] Generated Go code builds successfully
- [ ] Handler implementation works with new types
- [ ] Integration tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)