### PR TITLE
improve bundle flexibility in choices

### DIFF
--- a/dnd5e/api/v1alpha1/character.proto
+++ b/dnd5e/api/v1alpha1/character.proto
@@ -618,8 +618,8 @@ message ItemBundle {
 // Represents a single item in a bundle, which can be either a concrete item or a choice
 message BundleItem {
   oneof item_type {
-    CountedItemReference concrete_item = 1;  // Concrete item like "leather armor"
-    NestedChoice choice_item = 2;            // Choice like "a martial weapon"
+    CountedItemReference concrete_item = 1; // Concrete item like "leather armor"
+    NestedChoice choice_item = 2; // Choice like "a martial weapon"
   }
 }
 


### PR DESCRIPTION
This pull request refactors the `ItemBundle` message in the `dnd5e/api/v1alpha1/character.proto` file to provide more flexibility in representing items within a bundle. The key change introduces a new `BundleItem` message to handle both concrete items and choices.

### Changes to `ItemBundle` structure:

* Replaced the `CountedItemReference` list in `ItemBundle` with a new `BundleItem` list, allowing each item in the bundle to be either a concrete item (`CountedItemReference`) or a choice (`NestedChoice`). (`[dnd5e/api/v1alpha1/character.protoL615-R623](diffhunk://#diff-3f0c0962f6cf70256ee1a647d93f75f35209a6e0e1ac7f1f0263b498f9c79d83L615-R623)`)
* Added the `BundleItem` message definition, which uses a `oneof` field to distinguish between `concrete_item` and `choice_item`. (`[dnd5e/api/v1alpha1/character.protoL615-R623](diffhunk://#diff-3f0c0962f6cf70256ee1a647d93f75f35209a6e0e1ac7f1f0263b498f9c79d83L615-R623)`)