### PR TITLE
feat: add choice fields to update requests and improve draft structure

### DIFF
--- a/dnd5e/api/v1alpha1/character.proto
+++ b/dnd5e/api/v1alpha1/character.proto
@@ -261,8 +261,8 @@ message DeleteCharacterResponse {
   string message = 1;
 }
 
-// Character draft with optional fields
-message CharacterDraft {
+// Character draft data for storage with optional fields
+message CharacterDraftData {
   // Unique identifier
   string id = 1;
 
@@ -336,8 +336,8 @@ message DraftMetadata {
   string discord_message_id = 4;
 }
 
-// Hydrated character draft with full details for responses
-message CharacterDraftDetailed {
+// Character draft with full details for responses
+message CharacterDraft {
   // Unique identifier
   string id = 1;
 
@@ -379,11 +379,11 @@ message CreateDraftRequest {
   string session_id = 2; // Optional
 
   // Can optionally provide initial data
-  CharacterDraft initial_data = 3;
+  CharacterDraftData initial_data = 3;
 }
 
 message CreateDraftResponse {
-  CharacterDraftDetailed draft = 1;
+  CharacterDraft draft = 1;
 }
 
 // Request to get a draft
@@ -392,7 +392,7 @@ message GetDraftRequest {
 }
 
 message GetDraftResponse {
-  CharacterDraftDetailed draft = 1;
+  CharacterDraft draft = 1;
 }
 
 // Request to update a draft
@@ -400,14 +400,14 @@ message UpdateDraftRequest {
   string draft_id = 1;
 
   // Only provided fields will be updated
-  CharacterDraft updates = 2;
+  CharacterDraftData updates = 2;
 
   // Which fields to update (field mask pattern)
   repeated string update_mask = 3;
 }
 
 message UpdateDraftResponse {
-  CharacterDraftDetailed draft = 1;
+  CharacterDraft draft = 1;
 
   // Any validation warnings (not errors)
   repeated ValidationWarning warnings = 2;
@@ -455,32 +455,32 @@ message UpdateSkillsRequest {
 
 // Section-based update responses
 message UpdateNameResponse {
-  CharacterDraftDetailed draft = 1;
+  CharacterDraft draft = 1;
   repeated ValidationWarning warnings = 2;
 }
 
 message UpdateRaceResponse {
-  CharacterDraftDetailed draft = 1;
+  CharacterDraft draft = 1;
   repeated ValidationWarning warnings = 2;
 }
 
 message UpdateClassResponse {
-  CharacterDraftDetailed draft = 1;
+  CharacterDraft draft = 1;
   repeated ValidationWarning warnings = 2;
 }
 
 message UpdateBackgroundResponse {
-  CharacterDraftDetailed draft = 1;
+  CharacterDraft draft = 1;
   repeated ValidationWarning warnings = 2;
 }
 
 message UpdateAbilityScoresResponse {
-  CharacterDraftDetailed draft = 1;
+  CharacterDraft draft = 1;
   repeated ValidationWarning warnings = 2;
 }
 
 message UpdateSkillsResponse {
-  CharacterDraftDetailed draft = 1;
+  CharacterDraft draft = 1;
   repeated ValidationWarning warnings = 2;
 }
 
@@ -500,7 +500,7 @@ message ListDraftsRequest {
 }
 
 message ListDraftsResponse {
-  repeated CharacterDraftDetailed drafts = 1;
+  repeated CharacterDraft drafts = 1;
   string next_page_token = 2;
 }
 
@@ -526,7 +526,7 @@ message GetDraftPreviewRequest {
 }
 
 message GetDraftPreviewResponse {
-  CharacterDraftDetailed draft = 1; // The draft with choices
+  CharacterDraft draft = 1; // The draft with choices
   Character preview = 2; // Computed character state
   repeated ValidationWarning warnings = 3;
   repeated ValidationError errors = 4;

--- a/dnd5e/api/v1alpha1/character.proto
+++ b/dnd5e/api/v1alpha1/character.proto
@@ -282,20 +282,20 @@ message CharacterDraftData {
   Alignment alignment = 10;
 
   // Store player choices instead of computed state
-  repeated ChoiceSelection choices = 20;
+  repeated ChoiceSelection choices = 11;
 
   // Track what steps are complete
-  CreationProgress progress = 13;
+  CreationProgress progress = 12;
 
   // When this draft expires (e.g., 30 days)
-  int64 expires_at = 14;
+  int64 expires_at = 13;
 
   // Timestamps
-  int64 created_at = 16;
-  int64 updated_at = 17;
+  int64 created_at = 14;
+  int64 updated_at = 15;
 
   // Metadata
-  DraftMetadata metadata = 15;
+  DraftMetadata metadata = 16;
 }
 
 // Tracks which parts of character creation are complete
@@ -357,20 +357,20 @@ message CharacterDraft {
   Alignment alignment = 10;
 
   // Store player choices
-  repeated ChoiceSelection choices = 20;
+  repeated ChoiceSelection choices = 11;
 
   // Track what steps are complete
-  CreationProgress progress = 13;
+  CreationProgress progress = 12;
 
   // When this draft expires (e.g., 30 days)
-  int64 expires_at = 14;
+  int64 expires_at = 13;
 
   // Timestamps
-  int64 created_at = 16;
-  int64 updated_at = 17;
+  int64 created_at = 14;
+  int64 updated_at = 15;
 
   // Metadata
-  DraftMetadata metadata = 15;
+  DraftMetadata metadata = 16;
 }
 
 // Request to create a draft

--- a/dnd5e/api/v1alpha1/character.proto
+++ b/dnd5e/api/v1alpha1/character.proto
@@ -1044,10 +1044,9 @@ message Spell {
 enum ChoiceSource {
   CHOICE_SOURCE_UNSPECIFIED = 0;
   CHOICE_SOURCE_RACE = 1;
-  CHOICE_SOURCE_CLASS = 2;
-  CHOICE_SOURCE_BACKGROUND = 3;
-  CHOICE_SOURCE_SUBRACE = 4;
-  CHOICE_SOURCE_FEATURE = 5; // For class features that grant choices
+  CHOICE_SOURCE_SUBRACE = 2;
+  CHOICE_SOURCE_CLASS = 3;
+  CHOICE_SOURCE_BACKGROUND = 4;
 }
 
 // Tracks a choice made during character creation

--- a/dnd5e/api/v1alpha1/character.proto
+++ b/dnd5e/api/v1alpha1/character.proto
@@ -25,6 +25,9 @@ service CharacterService {
   // Validation
   rpc ValidateDraft(ValidateDraftRequest) returns (ValidateDraftResponse);
 
+  // Get a preview of what the character would look like if finalized
+  rpc GetDraftPreview(GetDraftPreviewRequest) returns (GetDraftPreviewResponse);
+
   // Character finalization
   rpc FinalizeDraft(FinalizeDraftRequest) returns (FinalizeDraftResponse);
 
@@ -269,7 +272,7 @@ message CharacterDraft {
   // Session if part of one
   string session_id = 3;
 
-  // All fields are optional during draft
+  // Identity fields - stored as enums
   string name = 4;
   Race race = 5;
   Subrace subrace = 6;
@@ -277,14 +280,19 @@ message CharacterDraft {
   Background background = 8;
   AbilityScores ability_scores = 9;
   Alignment alignment = 10;
-  repeated Skill starting_skills = 11;
-  repeated Language additional_languages = 12;
+
+  // Store player choices instead of computed state
+  repeated ChoiceSelection choices = 20;
 
   // Track what steps are complete
   CreationProgress progress = 13;
 
   // When this draft expires (e.g., 30 days)
   int64 expires_at = 14;
+
+  // Timestamps
+  int64 created_at = 16;
+  int64 updated_at = 17;
 
   // Metadata
   DraftMetadata metadata = 15;
@@ -328,6 +336,43 @@ message DraftMetadata {
   string discord_message_id = 4;
 }
 
+// Hydrated character draft with full details for responses
+message CharacterDraftDetailed {
+  // Unique identifier
+  string id = 1;
+
+  // Player creating this character
+  string player_id = 2;
+
+  // Session if part of one
+  string session_id = 3;
+
+  // Identity fields
+  string name = 4;
+  RaceInfo race = 5;
+  SubraceInfo subrace = 6;
+  ClassInfo class = 7;
+  BackgroundInfo background = 8;
+  AbilityScores ability_scores = 9;
+  Alignment alignment = 10;
+
+  // Store player choices
+  repeated ChoiceSelection choices = 20;
+
+  // Track what steps are complete
+  CreationProgress progress = 13;
+
+  // When this draft expires (e.g., 30 days)
+  int64 expires_at = 14;
+
+  // Timestamps
+  int64 created_at = 16;
+  int64 updated_at = 17;
+
+  // Metadata
+  DraftMetadata metadata = 15;
+}
+
 // Request to create a draft
 message CreateDraftRequest {
   string player_id = 1;
@@ -338,7 +383,7 @@ message CreateDraftRequest {
 }
 
 message CreateDraftResponse {
-  CharacterDraft draft = 1;
+  CharacterDraftDetailed draft = 1;
 }
 
 // Request to get a draft
@@ -347,7 +392,7 @@ message GetDraftRequest {
 }
 
 message GetDraftResponse {
-  CharacterDraft draft = 1;
+  CharacterDraftDetailed draft = 1;
 }
 
 // Request to update a draft
@@ -362,7 +407,7 @@ message UpdateDraftRequest {
 }
 
 message UpdateDraftResponse {
-  CharacterDraft draft = 1;
+  CharacterDraftDetailed draft = 1;
 
   // Any validation warnings (not errors)
   repeated ValidationWarning warnings = 2;
@@ -410,32 +455,32 @@ message UpdateSkillsRequest {
 
 // Section-based update responses
 message UpdateNameResponse {
-  CharacterDraft draft = 1;
+  CharacterDraftDetailed draft = 1;
   repeated ValidationWarning warnings = 2;
 }
 
 message UpdateRaceResponse {
-  CharacterDraft draft = 1;
+  CharacterDraftDetailed draft = 1;
   repeated ValidationWarning warnings = 2;
 }
 
 message UpdateClassResponse {
-  CharacterDraft draft = 1;
+  CharacterDraftDetailed draft = 1;
   repeated ValidationWarning warnings = 2;
 }
 
 message UpdateBackgroundResponse {
-  CharacterDraft draft = 1;
+  CharacterDraftDetailed draft = 1;
   repeated ValidationWarning warnings = 2;
 }
 
 message UpdateAbilityScoresResponse {
-  CharacterDraft draft = 1;
+  CharacterDraftDetailed draft = 1;
   repeated ValidationWarning warnings = 2;
 }
 
 message UpdateSkillsResponse {
-  CharacterDraft draft = 1;
+  CharacterDraftDetailed draft = 1;
   repeated ValidationWarning warnings = 2;
 }
 
@@ -455,7 +500,7 @@ message ListDraftsRequest {
 }
 
 message ListDraftsResponse {
-  repeated CharacterDraft drafts = 1;
+  repeated CharacterDraftDetailed drafts = 1;
   string next_page_token = 2;
 }
 
@@ -473,6 +518,18 @@ message ValidateDraftResponse {
 
   // What's still needed
   repeated CreationStep missing_steps = 5;
+}
+
+// Request to get a preview of the character
+message GetDraftPreviewRequest {
+  string draft_id = 1;
+}
+
+message GetDraftPreviewResponse {
+  CharacterDraftDetailed draft = 1; // The draft with choices
+  Character preview = 2; // Computed character state
+  repeated ValidationWarning warnings = 3;
+  repeated ValidationError errors = 4;
 }
 
 // Request to finalize draft
@@ -978,6 +1035,33 @@ message Spell {
 
   // Area of effect
   AreaOfEffect area_of_effect = 14;
+}
+
+// Source of a choice during character creation
+enum ChoiceSource {
+  CHOICE_SOURCE_UNSPECIFIED = 0;
+  CHOICE_SOURCE_RACE = 1;
+  CHOICE_SOURCE_CLASS = 2;
+  CHOICE_SOURCE_BACKGROUND = 3;
+  CHOICE_SOURCE_SUBRACE = 4;
+  CHOICE_SOURCE_FEATURE = 5; // For class features that grant choices
+}
+
+// Tracks a choice made during character creation
+message ChoiceSelection {
+  string choice_id = 1; // ID from Choice in RaceInfo/ClassInfo
+  ChoiceType choice_type = 2; // EQUIPMENT, SKILL, etc.
+  ChoiceSource source = 3; // Where this choice came from
+  repeated string selected_keys = 4; // What was selected
+
+  // For ability score choices
+  repeated AbilityScoreChoice ability_score_choices = 5;
+}
+
+// Represents an ability score bonus selection
+message AbilityScoreChoice {
+  Ability ability = 1;
+  int32 bonus = 2;
 }
 
 // Spell damage information

--- a/dnd5e/api/v1alpha1/character.proto
+++ b/dnd5e/api/v1alpha1/character.proto
@@ -423,16 +423,19 @@ message UpdateRaceRequest {
   string draft_id = 1;
   Race race = 2;
   Subrace subrace = 3; // Optional, required for some races
+  repeated ChoiceSelection race_choices = 4; // Choices made for this race
 }
 
 message UpdateClassRequest {
   string draft_id = 1;
   Class class = 2;
+  repeated ChoiceSelection class_choices = 3; // Choices made for this class
 }
 
 message UpdateBackgroundRequest {
   string draft_id = 1;
   Background background = 2;
+  repeated ChoiceSelection background_choices = 3; // Choices made for this background
 }
 
 message UpdateAbilityScoresRequest {


### PR DESCRIPTION
## Summary
Follow-up improvements to the choice-based character draft structure:

## Changes
- **Improved naming**: `CharacterDraftData` for storage, `CharacterDraft` for responses
- **Sequential field numbering**: Fixed jumbled field numbers (8,9,10,20,13) to sequential 1-16
- **Choice fields in update requests**: Added choice fields to race/class/background updates
- **Refined ChoiceSource enum**: Clean 4-value enum (race/subrace/class/background)

## New Request Fields
```protobuf
message UpdateRaceRequest {
  string draft_id = 1;
  Race race = 2;
  Subrace subrace = 3;
  repeated ChoiceSelection race_choices = 4; // NEW
}

message UpdateClassRequest {
  string draft_id = 1;
  Class class = 2;
  repeated ChoiceSelection class_choices = 3; // NEW
}

message UpdateBackgroundRequest {
  string draft_id = 1;
  Background background = 2;
  repeated ChoiceSelection background_choices = 3; // NEW
}
```

## Rationale
These changes make the API much more practical for real implementation:
1. Clients can send both the selection AND choices in one atomic operation
2. Clear separation between storage format and response format
3. Proper tracking of choice sources including subrace distinctions

🤖 Generated with Claude Code