### PR TITLE
feat: Add encounter.proto for D&D 5e dungeon encounters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# Claude AI Development Guidelines for rpg-api-protos
+
+## 🚨 CRITICAL: Proto Repository Workflow
+
+### Proto Changes Go to Feature Branches
+**NEVER push to the `generated` branch** - This branch is managed by CI/CD:
+1. Create feature branches from `main` for proto changes
+2. Only edit `.proto` files on feature branches
+3. When PRs are merged to `main`, CI automatically:
+   - Builds the protos
+   - Pushes generated code to `generated` branch
+   - Tags the release
+
+### Correct Workflow Example
+```bash
+# ✅ GOOD: Feature branch for proto changes
+git checkout main
+git pull origin main
+git checkout -b feat/add-encounter-proto
+# Edit proto files only
+git add proto/dnd5e/api/v1alpha1/encounter.proto
+git commit -m "feat: Add encounter.proto"
+git push origin feat/add-encounter-proto
+# Create PR to main
+
+# ❌ BAD: Working on generated branch
+git checkout generated  # NEVER do this for proto edits
+```
+
+## Proto Development Guidelines
+
+### Use Existing Common Types
+When creating new protos, check `api/v1alpha1/room_common.proto` for reusable types:
+- `Position` - 2D/3D coordinates
+- `GridType` - Grid system enum (square, hex, gridless)
+- `Entity` - Generic entity definition
+- `RoomConfig` - Room configuration
+- Error types and validation
+
+### Naming Conventions
+- Services: `<Domain>Service` (e.g., `EncounterService`)
+- Messages: PascalCase (e.g., `DungeonStartRequest`)
+- Fields: snake_case (e.g., `character_id`)
+- Enums: UPPER_SNAKE_CASE (e.g., `GRID_TYPE_SQUARE`)
+
+### Package Structure
+```
+proto/
+├── api/v1alpha1/           # Core RPG toolkit APIs
+│   ├── room_common.proto   # Shared room types
+│   ├── room_spatial.proto  # Spatial queries
+│   └── ...
+└── dnd5e/api/v1alpha1/     # D&D 5e specific APIs
+    ├── character.proto
+    ├── encounter.proto     # NEW: Encounter management
+    └── ...
+```
+
+## Remember
+- Proto files are the source of truth
+- Generated code is ephemeral - never edit it
+- Always work from `main` branch for proto changes
+- Use semantic commit messages for clear history

--- a/proto/dnd5e/api/v1alpha1/encounter.proto
+++ b/proto/dnd5e/api/v1alpha1/encounter.proto
@@ -1,0 +1,59 @@
+syntax = "proto3";
+
+package dnd5e.api.v1alpha1;
+
+import "api/v1alpha1/room_common.proto";
+
+option go_package = "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha1";
+
+// Note: Using Position from api.v1alpha1.room_common
+
+// EntityPlacement represents where an entity is positioned
+message EntityPlacement {
+  // Unique identifier for the entity
+  string entity_id = 1;
+  // Type of entity (e.g., "character", "monster", "object")
+  string entity_type = 2;
+  // Position in the room
+  api.v1alpha1.Position position = 3;
+}
+
+// Room represents a spatial area where encounters take place
+message Room {
+  // Unique identifier for the room
+  string id = 1;
+  // Type of room (e.g., "dungeon", "tavern", "outdoor")
+  string type = 2;
+  // Width of the room in grid units
+  int32 width = 3;
+  // Height of the room in grid units
+  int32 height = 4;
+  // Grid system used in this room
+  api.v1alpha1.GridType grid_type = 5;
+  // Entities placed in the room
+  repeated EntityPlacement entities = 6;
+  // Custom metadata for the room
+  map<string, string> metadata = 7;
+}
+
+// DungeonStartRequest initiates a simple dungeon encounter
+message DungeonStartRequest {
+  // ID of the character entering the dungeon
+  string character_id = 1;
+}
+
+// DungeonStartResponse contains the generated encounter
+message DungeonStartResponse {
+  // Unique identifier for this encounter
+  string encounter_id = 1;
+  // The generated room
+  Room room = 2;
+  // Where the character starts in the room
+  EntityPlacement character_placement = 3;
+}
+
+// EncounterService manages D&D 5e encounters
+service EncounterService {
+  // DungeonStart generates a simple starting room for testing
+  rpc DungeonStart(DungeonStartRequest) returns (DungeonStartResponse);
+}


### PR DESCRIPTION
## Summary
- Add `encounter.proto` to support basic dungeon encounter generation
- Reuse existing types from `room_common.proto` for consistency
- Implement `DungeonStart` RPC as minimal viable encounter system

## Details
This PR introduces the encounter proto definition to support rendering encounters in rpg-dnd5e-web:

### Key Components
- **Room message**: Matches rpg-toolkit's RoomData pattern with id, type, dimensions, grid type, entities, and metadata
- **EntityPlacement**: Tracks entity positions using the common Position type
- **DungeonStart RPC**: Simple service to generate a starting room with character placement

### Design Decisions
- Uses existing `Position` and `GridType` from `api/v1alpha1/room_common.proto` rather than duplicating
- Keeps Room structure minimal for MVP while matching toolkit patterns
- Float coordinates in Position support all grid types including gridless

### Testing
Proto compilation verified locally with `make generate`

Closes #31

🤖 Generated with [Claude Code](https://claude.ai/code)