### PR TITLE
fix: Use fully qualified go_package_prefix with source_relative paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,12 +56,7 @@ jobs:
         run: buf generate
       
       - name: Generate mocks
-        run: |
-          # Generate mocks for gRPC services
-          mkdir -p gen/go/clients/dnd5e/api/v1alpha1/mocks
-          mockgen -source=gen/go/clients/dnd5e/api/v1alpha1/character_grpc.pb.go -destination=gen/go/clients/dnd5e/api/v1alpha1/mocks/character_service.go -package=mocks
-          mkdir -p gen/go/clients/api/v1alpha1/mocks
-          mockgen -source=gen/go/clients/api/v1alpha1/dice_grpc.pb.go -destination=gen/go/clients/api/v1alpha1/mocks/dice_service.go -package=mocks
+        run: make mocks
       
       - name: Verify Go generation
         run: |
@@ -112,10 +107,7 @@ jobs:
       - name: Generate all code
         run: |
           buf generate
-          mkdir -p gen/go/clients/dnd5e/api/v1alpha1/mocks
-          mockgen -source=gen/go/clients/dnd5e/api/v1alpha1/character_grpc.pb.go -destination=gen/go/clients/dnd5e/api/v1alpha1/mocks/character_service.go -package=mocks
-          mkdir -p gen/go/clients/api/v1alpha1/mocks
-          mockgen -source=gen/go/clients/api/v1alpha1/dice_grpc.pb.go -destination=gen/go/clients/api/v1alpha1/mocks/dice_service.go -package=mocks
+          make mocks
       
       - name: Setup Go module
         run: |

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,17 @@ test: ## Run tests (lint + format check + generate + mocks)
 	$(MAKE) mocks
 
 mocks: ## Generate mocks for gRPC services
-	mkdir -p gen/go/clients/dnd5e/api/v1alpha1/mocks
-	mockgen -source=gen/go/clients/dnd5e/api/v1alpha1/character_grpc.pb.go -destination=gen/go/clients/dnd5e/api/v1alpha1/mocks/character_service.go -package=mocks
-	mkdir -p gen/go/clients/api/v1alpha1/mocks
-	mockgen -source=gen/go/clients/api/v1alpha1/dice_grpc.pb.go -destination=gen/go/clients/api/v1alpha1/mocks/dice_service.go -package=mocks
+	# D&D 5e services
+	mkdir -p gen/go/dnd5e/api/v1alpha1/mocks
+	mockgen -source=gen/go/dnd5e/api/v1alpha1/character_grpc.pb.go -destination=gen/go/dnd5e/api/v1alpha1/mocks/character_service.go -package=mocks
+	mockgen -source=gen/go/dnd5e/api/v1alpha1/encounter_grpc.pb.go -destination=gen/go/dnd5e/api/v1alpha1/mocks/encounter_service.go -package=mocks
+	# Core API services
+	mkdir -p gen/go/api/v1alpha1/mocks
+	mockgen -source=gen/go/api/v1alpha1/dice_grpc.pb.go -destination=gen/go/api/v1alpha1/mocks/dice_service.go -package=mocks
+	mockgen -source=gen/go/api/v1alpha1/room_environments_grpc.pb.go -destination=gen/go/api/v1alpha1/mocks/environment_service.go -package=mocks
+	mockgen -source=gen/go/api/v1alpha1/room_selectables_grpc.pb.go -destination=gen/go/api/v1alpha1/mocks/selection_table_service.go -package=mocks
+	mockgen -source=gen/go/api/v1alpha1/room_spatial_grpc.pb.go -destination=gen/go/api/v1alpha1/mocks/spatial_service.go -package=mocks
+	mockgen -source=gen/go/api/v1alpha1/room_spawn_grpc.pb.go -destination=gen/go/api/v1alpha1/mocks/spawn_service.go -package=mocks
 
 breaking: ## Check for breaking changes against main branch
 	buf breaking --against '.git#branch=main'

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -3,17 +3,17 @@ managed:
   enabled: true
   override:
     - file_option: go_package_prefix
-      value: clients
+      value: github.com/KirkDiggler/rpg-api-protos/gen/go/clients
 plugins:
   # Go plugins
   - remote: buf.build/protocolbuffers/go
     out: gen/go
     opt:
-      - paths=import
+      - paths=source_relative
   - remote: buf.build/grpc/go
     out: gen/go
     opt:
-      - paths=import
+      - paths=source_relative
       - require_unimplemented_servers=false
   
   # TypeScript plugins - single plugin for both messages and Connect services


### PR DESCRIPTION
## Summary
This PR fixes the Go import paths in generated code to be fully qualified, resolving linter issues in consuming projects like rpg-api.

## Problem
The generated code was using relative imports like `clients/api/v1alpha1` which causes linter errors in consuming projects.

## Solution
1. Updated `go_package_prefix` to use the full module path
2. Switched from `paths=import` to `paths=source_relative` to prevent path doubling

## Result
Generated imports are now fully qualified:
```go
import v1alpha1 "github.com/KirkDiggler/rpg-api-protos/gen/go/clients/api/v1alpha1"
```

This should resolve the linter complaints in rpg-api about non-standard import paths.

🤖 Generated with [Claude Code](https://claude.ai/code)