### PR TITLE
fix: Revert to relative go_package_prefix to fix import resolution

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -3,7 +3,7 @@ managed:
   enabled: true
   override:
     - file_option: go_package_prefix
-      value: github.com/KirkDiggler/rpg-api-protos/gen/go/clients
+      value: clients
 plugins:
   # Go plugins
   - remote: buf.build/protocolbuffers/go


### PR DESCRIPTION
## Summary
This PR fixes the Go import resolution error that's causing CI failures.

## Problem
After PR #35, the CI is failing with:
```
module github.com/KirkDiggler/rpg-api-protos@latest found (v0.1.19), 
but does not contain package github.com/KirkDiggler/rpg-api-protos/gen/go/clients/api/v1alpha1
```

## Root Cause
Using the full module path in `go_package_prefix` causes Go to treat imports as external modules. Since the generated code lives in its own module at `gen/go`, Go tries to fetch these imports from the parent module which doesn't contain the generated code.

## Solution
Revert `go_package_prefix` back to `clients` while keeping `paths=source_relative`. This allows:
- Relative imports within the generated module work correctly
- The directory structure remains as expected
- No import resolution errors

## Testing
Tested locally with `make generate && make mocks` - all files generate correctly.

🤖 Generated with [Claude Code](https://claude.ai/code)