### PR TITLE
fix: Switch back to paths=import for proper module resolution

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -3,17 +3,17 @@ managed:
   enabled: true
   override:
     - file_option: go_package_prefix
-      value: clients
+      value: github.com/KirkDiggler/rpg-api-protos/gen/go
 plugins:
   # Go plugins
   - remote: buf.build/protocolbuffers/go
     out: gen/go
     opt:
-      - paths=import
+      - paths=source_relative
   - remote: buf.build/grpc/go
     out: gen/go
     opt:
-      - paths=import
+      - paths=source_relative
       - require_unimplemented_servers=false
   
   # TypeScript plugins - single plugin for both messages and Connect services

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -3,7 +3,7 @@ managed:
   enabled: true
   override:
     - file_option: go_package_prefix
-      value: github.com/KirkDiggler/rpg-api-protos/gen/go/clients
+      value: clients
 plugins:
   # Go plugins
   - remote: buf.build/protocolbuffers/go

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -9,11 +9,11 @@ plugins:
   - remote: buf.build/protocolbuffers/go
     out: gen/go
     opt:
-      - paths=source_relative
+      - paths=import
   - remote: buf.build/grpc/go
     out: gen/go
     opt:
-      - paths=source_relative
+      - paths=import
       - require_unimplemented_servers=false
   
   # TypeScript plugins - single plugin for both messages and Connect services


### PR DESCRIPTION
## Summary
- Switch protoc-gen-go options from paths=source_relative back to paths=import
- This generates the proper directory structure that matches import statements

## Context
After merging PR #35, we discovered that paths=source_relative caused a mismatch between:
- Import statements expecting: `import v1alpha1 "clients/api/v1alpha1"`
- Actual file location: `api/v1alpha1/` (no clients directory)

Now that the generated files exist from the previous build, switching back to paths=import will create the correct directory structure.

## Test plan
- [x] Updated buf.gen.yaml to use paths=import
- [ ] Wait for CI to generate code
- [ ] Verify rpg-api can build with the new import paths