### PR TITLE
feat: Convert ChoiceData to use oneof pattern for type safety

### DIFF
--- a/dnd5e/api/v1alpha1/character.proto
+++ b/dnd5e/api/v1alpha1/character.proto
@@ -1127,7 +1127,7 @@ message ChoiceData {
   ChoiceCategory category = 1; // Type of choice (skills, languages, etc.)
   ChoiceSource source = 2; // Where this choice came from
   string choice_id = 3; // Specific choice identifier
-  
+
   // Type-safe selection using oneof pattern (matching toolkit refactoring)
   oneof selection {
     string name = 4;


### PR DESCRIPTION
## Summary
- Converts `ChoiceData.selection` from `google.protobuf.Any` to a type-safe `oneof` pattern
- Aligns with the toolkit refactoring in [rpg-toolkit PR #159](https://github.com/KirkDiggler/rpg-toolkit/pull/159)
- Provides compile-time type safety instead of runtime type assertions

## Changes
- Replace `google.protobuf.Any` with `oneof selection` containing all possible choice types
- Add wrapper messages for repeated fields (required by protobuf for oneof)
- Add missing `ChoiceCategory` enum values for all selection types
- Remove unnecessary `google/protobuf/any.proto` import

## Breaking Changes
- `ChoiceData.selection` field changed from `Any` to `oneof`
- This is acceptable as we're still in `v1alpha1` with no prior versions to maintain compatibility with

## Benefits
- **Type safety**: No runtime type assertions needed
- **Clear API contract**: Developers can see exactly what selection types are available
- **Direct mapping**: Aligns perfectly with the Go toolkit implementation
- **Proto validation**: Ensures only one selection type is set at a time

🤖 Generated with [Claude Code](https://claude.ai/code)