### PR TITLE
feat: Add enum fields to CharacterDraft for v1alpha1

### DIFF
--- a/dnd5e/api/v1alpha1/character.proto
+++ b/dnd5e/api/v1alpha1/character.proto
@@ -387,6 +387,13 @@ message CharacterDraft {
 
   // Metadata
   DraftMetadata metadata = 16;
+
+  // Enum fields for v1alpha1 - these are the actual values stored
+  // The full info objects above can be left empty/null
+  Race race_id = 17;
+  Subrace subrace_id = 18;
+  Class class_id = 19;
+  Background background_id = 20;
 }
 
 // Request to create a draft


### PR DESCRIPTION
## Summary
- Add race_id, subrace_id, class_id, background_id enum fields to CharacterDraft proto
- Allows storing just the enum values without full info objects for v1alpha1
- Simplifies the API and avoids needing hacks in both rpg-api and the app

## Test Plan
- [ ] Proto files compile successfully
- [ ] rpg-api can use the new enum fields
- [ ] App can read enum values directly without parsing info objects

🤖 Generated with [Claude Code](https://claude.ai/code)