### PR TITLE
fix: remove deprecated ChoiceSelection and use ChoiceData

### DIFF
--- a/dnd5e/api/v1alpha1/character.proto
+++ b/dnd5e/api/v1alpha1/character.proto
@@ -446,19 +446,19 @@ message UpdateRaceRequest {
   string draft_id = 1;
   Race race = 2;
   Subrace subrace = 3; // Optional, required for some races
-  repeated ChoiceSelection race_choices = 4; // Choices made for this race
+  repeated ChoiceData race_choices = 4; // Choices made for this race
 }
 
 message UpdateClassRequest {
   string draft_id = 1;
   Class class = 2;
-  repeated ChoiceSelection class_choices = 3; // Choices made for this class
+  repeated ChoiceData class_choices = 3; // Choices made for this class
 }
 
 message UpdateBackgroundRequest {
   string draft_id = 1;
   Background background = 2;
-  repeated ChoiceSelection background_choices = 3; // Choices made for this background
+  repeated ChoiceData background_choices = 3; // Choices made for this background
 }
 
 message UpdateAbilityScoresRequest {
@@ -1182,22 +1182,8 @@ message ClassChoice {
   // Could add subclass later when implemented
 }
 
-// Tracks a choice made during character creation (deprecated - use ChoiceData)
-message ChoiceSelection {
-  string choice_id = 1; // ID from Choice in RaceInfo/ClassInfo
-  ChoiceCategory choice_type = 2; // EQUIPMENT, SKILL, etc. (was ChoiceType)
-  ChoiceSource source = 3; // Where this choice came from
-  repeated string selected_keys = 4; // What was selected
-
-  // For ability score choices
-  repeated AbilityScoreChoice ability_score_choices = 5;
-}
-
-// Represents an ability score bonus selection
-message AbilityScoreChoice {
-  Ability ability = 1;
-  int32 bonus = 2;
-}
+// REMOVED: ChoiceSelection - replaced by ChoiceData
+// REMOVED: AbilityScoreChoice - no longer needed
 
 // Spell damage information
 message SpellDamage {


### PR DESCRIPTION
## Summary
- Replace deprecated `ChoiceSelection` with `ChoiceData` in all Update request messages
- Remove unused message definitions that are no longer needed
- Complete the migration to the new typed choice system

## Changes
- `UpdateRaceRequest`: Now uses `repeated ChoiceData race_choices`
- `UpdateClassRequest`: Now uses `repeated ChoiceData class_choices`  
- `UpdateBackgroundRequest`: Now uses `repeated ChoiceData background_choices`
- Removed `ChoiceSelection` message (deprecated)
- Removed `AbilityScoreChoice` message (no longer used)

## Breaking Changes
This is a breaking change for any clients using the Update endpoints with `ChoiceSelection`. They will need to migrate to using `ChoiceData` format with the typed oneof pattern.

## Next Steps
After this PR is merged:
1. The CI will automatically generate updated Go/TypeScript code on the `generated` branch
2. Update rpg-api to use the new generated code
3. Remove all ChoiceSelection conversion logic from the handlers

🤖 Generated with [Claude Code](https://claude.ai/code)