### PR TITLE
feat: Add missing character fields for features, traits, and resources

### DIFF
--- a/dnd5e/api/v1alpha1/character.proto
+++ b/dnd5e/api/v1alpha1/character.proto
@@ -62,6 +62,36 @@ service CharacterService {
   rpc RemoveFromInventory(RemoveFromInventoryRequest) returns (RemoveFromInventoryResponse);
 }
 
+// Character feature (class features, racial traits, etc)
+message CharacterFeature {
+  string id = 1;
+  string name = 2;
+  string description = 3;
+  string source = 4; // "class", "race", "background", etc
+  int32 level = 5; // Level when gained (0 for racial/background)
+}
+
+// Class resource (rage uses, ki points, etc)
+message ClassResource {
+  string name = 1;
+  int32 current = 2;
+  int32 maximum = 3;
+  string recharge = 4; // "short_rest", "long_rest", etc
+}
+
+// Spell slots by level
+message SpellSlots {
+  int32 level_1 = 1;
+  int32 level_2 = 2;
+  int32 level_3 = 3;
+  int32 level_4 = 4;
+  int32 level_5 = 5;
+  int32 level_6 = 6;
+  int32 level_7 = 7;
+  int32 level_8 = 8;
+  int32 level_9 = 9;
+}
+
 // Ability scores for a character
 message AbilityScores {
   // Strength score (3-18 before racial modifiers)
@@ -147,6 +177,22 @@ message Character {
 
   // Carrying capacity and encumbrance
   EncumbranceInfo encumbrance = 21;
+
+  // Class features and choices
+  repeated CharacterFeature features = 22;
+  repeated string fighting_styles = 23;
+
+  // Racial traits
+  repeated CharacterFeature racial_traits = 24;
+
+  // Background feature
+  CharacterFeature background_feature = 25;
+
+  // Class resources (rage uses, ki points, etc)
+  map<string, ClassResource> class_resources = 26;
+
+  // Spell slots for casters
+  SpellSlots spell_slots = 27;
 }
 
 // Ability modifiers calculated from scores

--- a/dnd5e/api/v1alpha1/character.proto
+++ b/dnd5e/api/v1alpha1/character.proto
@@ -71,12 +71,40 @@ message CharacterFeature {
   int32 level = 5; // Level when gained (0 for racial/background)
 }
 
+// Types of class resources in D&D 5e
+enum ClassResourceType {
+  CLASS_RESOURCE_TYPE_UNSPECIFIED = 0;
+  CLASS_RESOURCE_TYPE_RAGE = 1;
+  CLASS_RESOURCE_TYPE_BARDIC_INSPIRATION = 2;
+  CLASS_RESOURCE_TYPE_CHANNEL_DIVINITY = 3;
+  CLASS_RESOURCE_TYPE_WILD_SHAPE = 4;
+  CLASS_RESOURCE_TYPE_SECOND_WIND = 5;
+  CLASS_RESOURCE_TYPE_ACTION_SURGE = 6;
+  CLASS_RESOURCE_TYPE_KI_POINTS = 7;
+  CLASS_RESOURCE_TYPE_DIVINE_SENSE = 8;
+  CLASS_RESOURCE_TYPE_LAY_ON_HANDS = 9;
+  CLASS_RESOURCE_TYPE_SORCERY_POINTS = 10;
+  CLASS_RESOURCE_TYPE_ARCANE_RECOVERY = 11;
+  CLASS_RESOURCE_TYPE_INDOMITABLE = 12;
+  CLASS_RESOURCE_TYPE_SUPERIORITY_DICE = 13;
+}
+
+// Recharge timing for resources
+enum RechargeType {
+  RECHARGE_TYPE_UNSPECIFIED = 0;
+  RECHARGE_TYPE_SHORT_REST = 1;
+  RECHARGE_TYPE_LONG_REST = 2;
+  RECHARGE_TYPE_DAWN = 3;
+  RECHARGE_TYPE_NONE = 4; // Never recharges (consumable)
+}
+
 // Class resource (rage uses, ki points, etc)
 message ClassResource {
-  string name = 1;
-  int32 current = 2;
-  int32 maximum = 3;
-  string recharge = 4; // "short_rest", "long_rest", etc
+  ClassResourceType type = 1;
+  string name = 2; // Display name
+  int32 current = 3;
+  int32 maximum = 4;
+  RechargeType recharge = 5;
 }
 
 // Spell slots by level
@@ -189,7 +217,7 @@ message Character {
   CharacterFeature background_feature = 25;
 
   // Class resources (rage uses, ki points, etc)
-  map<string, ClassResource> class_resources = 26;
+  repeated ClassResource class_resources = 26;
 
   // Spell slots for casters
   SpellSlots spell_slots = 27;


### PR DESCRIPTION
## Summary
Adds missing fields to the Character proto message to capture all character data that is calculated during finalization.

## Changes
- Added  message for class features and racial traits
- Added  message for rage uses, ki points, etc
- Added  message for spell slot tracking
- Added new fields to Character message:
  -  - Class features like Second Wind, Rage
  -  - Fighter/Ranger fighting style selections
  -  - Darkvision, Keen Senses, etc
  -  - Military Rank, Researcher, etc
  -  - Rage uses, Ki points, Sorcery points
  -  - Spell slots for casters

## Testing
Once CI builds these protos and publishes to the `generated` branch:
1. Update rpg-api to use new fields in conversion
2. Enable TODO tests in finalize_gaps_test.go
3. Update React frontend to display new data

## Related
- Closes #46
- Next: rpg-api implementation issue
- Then: React display updates

🤖 Generated with [Claude Code](https://claude.ai/code)