### PR TITLE
feat: Remove sandbox_id fields and lifecycle methods

### DIFF
--- a/sandbox/api/v1alpha1/sandbox_common.proto
+++ b/sandbox/api/v1alpha1/sandbox_common.proto
@@ -136,13 +136,3 @@ message GenerationMetrics {
   repeated string toolkit_modules_used = 5;
   string generation_method = 6; // "procedural" or "static"
 }
-
-message SandboxInfo {
-  string sandbox_id = 1;
-  string entity_id = 2;
-  string experiment_name = 3;
-  string description = 4;
-  int64 created_at = 5;
-  int64 expires_at = 6;
-  int32 rooms_generated = 7;
-}

--- a/sandbox/api/v1alpha1/sandbox_room.proto
+++ b/sandbox/api/v1alpha1/sandbox_room.proto
@@ -26,18 +26,12 @@ service SandboxRoomService {
   rpc MoveEntity(MoveEntityRequest) returns (MoveEntityResponse);
   rpc RemoveEntity(RemoveEntityRequest) returns (RemoveEntityResponse);
   rpc GetEntitiesInRoom(GetEntitiesInRoomRequest) returns (GetEntitiesInRoomResponse);
-
-  // Sandbox Lifecycle
-  rpc CreateSandbox(CreateSandboxRequest) returns (CreateSandboxResponse);
-  rpc GetSandbox(GetSandboxRequest) returns (GetSandboxResponse);
-  rpc DeleteSandbox(DeleteSandboxRequest) returns (DeleteSandboxResponse);
 }
 
 // Room Generation - Procedural
 message GenerateRoomRequest {
-  string sandbox_id = 1;
-  GenerativeRoomConfig config = 2;
-  int64 seed = 3;
+  GenerativeRoomConfig config = 1;
+  int64 seed = 2;
 }
 
 message GenerateRoomResponse {
@@ -49,8 +43,7 @@ message GenerateRoomResponse {
 
 // Room Building - Static
 message BuildStaticRoomRequest {
-  string sandbox_id = 1;
-  StaticRoomConfig config = 2;
+  StaticRoomConfig config = 1;
 }
 
 message BuildStaticRoomResponse {
@@ -164,9 +157,8 @@ message GetRoomResponse {
 }
 
 message ListRoomsRequest {
-  string sandbox_id = 1;
-  int32 page_size = 2;
-  string page_token = 3;
+  int32 page_size = 1;
+  string page_token = 2;
 }
 
 message ListRoomsResponse {
@@ -180,36 +172,6 @@ message DeleteRoomRequest {
 }
 
 message DeleteRoomResponse {
-  bool success = 1;
-  string reason = 2;
-}
-
-// Sandbox Management
-message CreateSandboxRequest {
-  string entity_id = 1; // Following existing entity ownership pattern
-  string experiment_name = 2;
-  string description = 3;
-}
-
-message CreateSandboxResponse {
-  string sandbox_id = 1;
-  int64 created_at = 2;
-  int64 expires_at = 3; // TTL-based expiration
-}
-
-message GetSandboxRequest {
-  string sandbox_id = 1;
-}
-
-message GetSandboxResponse {
-  SandboxInfo sandbox = 1;
-}
-
-message DeleteSandboxRequest {
-  string sandbox_id = 1;
-}
-
-message DeleteSandboxResponse {
   bool success = 1;
   string reason = 2;
 }


### PR DESCRIPTION
## Summary
Remove misunderstood `sandbox_id` fields and lifecycle methods from sandbox namespace protos.

Based on the sandbox namespace implementation spec, 'sandbox' is just a namespace for experimental building tools, not a runtime concept requiring IDs or lifecycle management.

## Changes Made
- ✅ **Removed 7 sandbox_id fields** from request messages:
  - `GenerateRoomRequest.sandbox_id` 
  - `BuildStaticRoomRequest.sandbox_id`
  - `ListRoomsRequest.sandbox_id`
  - And 4 others in lifecycle messages
- ✅ **Removed unused sandbox lifecycle service methods**:
  - `CreateSandbox` / `CreateSandboxRequest` / `CreateSandboxResponse`
  - `GetSandbox` / `GetSandboxRequest` / `GetSandboxResponse`  
  - `DeleteSandbox` / `DeleteSandboxRequest` / `DeleteSandboxResponse`
- ✅ **Removed SandboxInfo message** (no longer referenced)
- ✅ **Renumbered proto field IDs** for cleaner API
- ✅ **No test updates needed** - No existing tests used removed functionality

## API Impact
The API now focuses on actual room-based functionality without sandbox concept overhead:

### Before (Confusing):
```protobuf
message GenerateRoomRequest {
  string sandbox_id = 1;  // Confusing - what's a sandbox?
  GenerativeRoomConfig config = 2;
  int64 seed = 3;
}
```

### After (Clear):
```protobuf  
message GenerateRoomRequest {
  GenerativeRoomConfig config = 1;  // Just room config
  int64 seed = 2;
}
```

## Implementation Benefits
- **Cleaner API** - No confusing sandbox_id validation required
- **Simpler handlers** - No ignore-but-validate logic needed  
- **Matches implementation spec** - Aligns with actual functionality
- **Ready for rpg-api implementation** - Clean contracts ready to implement

## Testing
- ✅ `buf lint` passes - Proto definitions valid
- ✅ `buf format` applied - Proper formatting  
- ✅ `buf generate` succeeds - Code generation works
- ✅ No existing test breakage - Generated mocks will update automatically

This aligns the proto definitions with the actual implementation plan which focuses on room-based operations without sandbox concept overhead.

🤖 Generated with [Claude Code](https://claude.ai/code)