### PR TITLE
feat: Add missing choice categories and validation enums

### DIFF
--- a/dnd5e/api/v1alpha1/character.proto
+++ b/dnd5e/api/v1alpha1/character.proto
@@ -826,6 +826,9 @@ enum ChoiceCategory {
   CHOICE_CATEGORY_CLASS = 13; // Class selection
   CHOICE_CATEGORY_BACKGROUND = 14; // Background selection
   CHOICE_CATEGORY_CANTRIPS = 15; // Cantrips known
+  CHOICE_CATEGORY_EXPERTISE = 16; // Expertise (double proficiency) choices
+  CHOICE_CATEGORY_SUBRACE = 17; // Subrace selection (e.g., High Elf, Mountain Dwarf)
+  CHOICE_CATEGORY_TRAITS = 18; // Racial or class traits (e.g., Draconic Ancestry)
 }
 
 // Character size category

--- a/dnd5e/api/v1alpha1/common.proto
+++ b/dnd5e/api/v1alpha1/common.proto
@@ -128,6 +128,7 @@ enum ValidationSource {
   VALIDATION_SOURCE_NAME = 5;
   VALIDATION_SOURCE_ALIGNMENT = 6;
   VALIDATION_SOURCE_LEVEL = 7;
+  VALIDATION_SOURCE_SUBRACE = 8; // Validation from subrace selection
 }
 
 // Fields that can have validation issues (matches toolkit constants)
@@ -147,4 +148,6 @@ enum ValidationField {
   VALIDATION_FIELD_CLASS = 12;
   VALIDATION_FIELD_BACKGROUND = 13;
   VALIDATION_FIELD_DRACONIC_ANCESTRY = 14;
+  VALIDATION_FIELD_SUBRACE = 15; // Subrace selection
+  VALIDATION_FIELD_TRAITS = 16; // Generic racial/class traits
 }


### PR DESCRIPTION
## Summary
Adds missing enums to proto definitions to support full character creation flow, particularly for rogues and characters with racial traits.

## Missing Enums Added

### ChoiceCategory
- `CHOICE_CATEGORY_EXPERTISE` (16): For rogue/bard expertise selections (double proficiency)
- `CHOICE_CATEGORY_SUBRACE` (17): For subrace selection (e.g., High Elf, Mountain Dwarf)
- `CHOICE_CATEGORY_TRAITS` (18): For racial/class trait selections (e.g., Draconic Ancestry)

### ValidationSource
- `VALIDATION_SOURCE_SUBRACE` (8): For validation originating from subrace requirements

### ValidationField  
- `VALIDATION_FIELD_SUBRACE` (15): For subrace selection validation
- `VALIDATION_FIELD_TRAITS` (16): For generic trait validation

## Problem
These missing enums were preventing proper display and validation of character choices in the UI:
- Rogues weren't showing expertise choices
- Racial traits weren't being tracked properly
- Subrace-specific validations couldn't be identified

## Testing
After this is merged and protos are regenerated:
1. Rogues should show expertise selection at level 1
2. Dragonborn should show draconic ancestry selection
3. Validation should properly identify subrace-related issues

🤖 Generated with [Claude Code](https://claude.ai/code)