### PR TITLE
Add group to classinfo

### DIFF
--- a/dnd5e/api/v1alpha1/character.proto
+++ b/dnd5e/api/v1alpha1/character.proto
@@ -874,6 +874,9 @@ message ClassInfo {
 
   // All choices (equipment, proficiencies, etc.)
   repeated Choice choices = 15;
+  
+  // we group the class info by class to allow subclasses to be in the list
+  Class group = 16;
 }
 
 // Deprecated: Use FeatureInfo instead for richer feature data


### PR DESCRIPTION
Adds group (Class enum) to CLass Info. wew are planning on adding all level 1 subclasses to simplify the UI