### PR TITLE
feat: Add comprehensive enums and choice messages for toolkit integration

### DIFF
--- a/dnd5e/api/v1alpha1/character.proto
+++ b/dnd5e/api/v1alpha1/character.proto
@@ -47,10 +47,10 @@ service CharacterService {
 
   // Dice rolling for character creation
   rpc RollAbilityScores(RollAbilityScoresRequest) returns (RollAbilityScoresResponse);
-  
+
   // Get requirements for character creation choices
   rpc GetRequirements(GetRequirementsRequest) returns (GetRequirementsResponse);
-  
+
   // Submit character creation choices
   rpc SubmitChoices(SubmitChoicesRequest) returns (SubmitChoicesResponse);
 
@@ -1381,7 +1381,7 @@ message ClassChoice {
 message EquipmentChoice {
   string choice_id = 1; // e.g., "fighter-armor-a"
   string description = 2; // Human-readable description
-  
+
   // Options for this choice
   repeated EquipmentOption options = 3;
 }
@@ -1390,7 +1390,7 @@ message EquipmentChoice {
 message EquipmentOption {
   string option_id = 1; // e.g., "leather-longbow"
   string description = 2;
-  
+
   // Equipment items granted by this option
   repeated EquipmentSelection items = 3;
 }
@@ -1412,7 +1412,7 @@ message ChoiceSubmission {
   ChoiceSource source = 2;
   string choice_id = 3; // Which choice this is for
   string option_id = 4; // Which option was selected (for equipment)
-  
+
   // Values selected (skills, languages, equipment, etc.)
   oneof values {
     SkillSelection skills = 5;
@@ -1461,7 +1461,7 @@ message ArmorProficiencySelection {
 message CharacterRequirements {
   // All choices that need to be made
   repeated RequiredChoice choices = 1;
-  
+
   // Validation state
   bool all_choices_made = 2;
   repeated string missing_choices = 3;
@@ -1474,7 +1474,7 @@ message RequiredChoice {
   ChoiceSource source = 3;
   string description = 4;
   int32 count = 5; // How many to choose
-  
+
   // Available options based on category
   oneof options {
     SkillOptions skill_options = 6;

--- a/dnd5e/api/v1alpha1/character.proto
+++ b/dnd5e/api/v1alpha1/character.proto
@@ -47,6 +47,12 @@ service CharacterService {
 
   // Dice rolling for character creation
   rpc RollAbilityScores(RollAbilityScoresRequest) returns (RollAbilityScoresResponse);
+  
+  // Get requirements for character creation choices
+  rpc GetRequirements(GetRequirementsRequest) returns (GetRequirementsResponse);
+  
+  // Submit character creation choices
+  rpc SubmitChoices(SubmitChoicesRequest) returns (SubmitChoicesResponse);
 
   // Equipment listing by type
   rpc ListEquipmentByType(ListEquipmentByTypeRequest) returns (ListEquipmentByTypeResponse);
@@ -1119,6 +1125,31 @@ message RollAbilityScoresResponse {
   int64 expires_at = 2;
 }
 
+// Request to get character creation requirements
+message GetRequirementsRequest {
+  string draft_id = 1;
+  Class class = 2; // Optional: get requirements for a specific class
+  Race race = 3; // Optional: get requirements for a specific race
+}
+
+// Response with character creation requirements
+message GetRequirementsResponse {
+  CharacterRequirements requirements = 1;
+}
+
+// Request to submit character creation choices
+message SubmitChoicesRequest {
+  string draft_id = 1;
+  repeated ChoiceSubmission submissions = 2;
+}
+
+// Response from submitting choices
+message SubmitChoicesResponse {
+  CharacterDraft draft = 1;
+  ValidationResult validation = 2;
+  CharacterRequirements remaining_requirements = 3;
+}
+
 // Roll assignment mapping for ability scores
 message RollAssignments {
   string strength_roll_id = 1;
@@ -1341,6 +1372,138 @@ message ClassChoice {
 
 // REMOVED: ChoiceSelection - replaced by ChoiceData
 // REMOVED: AbilityScoreChoice - no longer needed
+
+// ============================================================================
+// New messages for toolkit integration with type-safe enums
+// ============================================================================
+
+// Equipment choice for character creation
+message EquipmentChoice {
+  string choice_id = 1; // e.g., "fighter-armor-a"
+  string description = 2; // Human-readable description
+  
+  // Options for this choice
+  repeated EquipmentOption options = 3;
+}
+
+// Single equipment option within a choice
+message EquipmentOption {
+  string option_id = 1; // e.g., "leather-longbow"
+  string description = 2;
+  
+  // Equipment items granted by this option
+  repeated EquipmentSelection items = 3;
+}
+
+// A specific equipment item with quantity
+message EquipmentSelection {
+  oneof equipment {
+    Weapon weapon = 1;
+    Armor armor = 2;
+    Tool tool = 3;
+    string other_equipment_id = 4; // For non-weapon/armor/tool items
+  }
+  int32 quantity = 5; // Default 1
+}
+
+// Submission for a choice made by the player
+message ChoiceSubmission {
+  ChoiceCategory category = 1;
+  ChoiceSource source = 2;
+  string choice_id = 3; // Which choice this is for
+  string option_id = 4; // Which option was selected (for equipment)
+  
+  // Values selected (skills, languages, equipment, etc.)
+  oneof values {
+    SkillSelection skills = 5;
+    LanguageSelection languages = 6;
+    EquipmentSelection equipment = 7;
+    FightingStyleSelection fighting_style = 8;
+    ToolSelection tools = 9;
+    WeaponProficiencySelection weapon_proficiencies = 10;
+    ArmorProficiencySelection armor_proficiencies = 11;
+  }
+}
+
+// Skill selection
+message SkillSelection {
+  repeated Skill skills = 1;
+}
+
+// Language selection
+message LanguageSelection {
+  repeated Language languages = 1;
+}
+
+// Fighting style selection
+message FightingStyleSelection {
+  FightingStyle style = 1;
+}
+
+// Tool proficiency selection
+message ToolSelection {
+  repeated Tool tools = 1;
+}
+
+// Weapon proficiency selection
+message WeaponProficiencySelection {
+  repeated Weapon weapons = 1;
+  repeated EquipmentType categories = 2; // For "all martial weapons" etc.
+}
+
+// Armor proficiency selection
+message ArmorProficiencySelection {
+  repeated Armor armors = 1;
+  repeated EquipmentType categories = 2; // For "all light armor" etc.
+}
+
+// Requirements for character choices
+message CharacterRequirements {
+  // All choices that need to be made
+  repeated RequiredChoice choices = 1;
+  
+  // Validation state
+  bool all_choices_made = 2;
+  repeated string missing_choices = 3;
+}
+
+// A single required choice
+message RequiredChoice {
+  string choice_id = 1;
+  ChoiceCategory category = 2;
+  ChoiceSource source = 3;
+  string description = 4;
+  int32 count = 5; // How many to choose
+  
+  // Available options based on category
+  oneof options {
+    SkillOptions skill_options = 6;
+    LanguageOptions language_options = 7;
+    EquipmentChoice equipment_options = 8;
+    FightingStyleOptions fighting_style_options = 9;
+    ToolOptions tool_options = 10;
+  }
+}
+
+// Available skill options
+message SkillOptions {
+  repeated Skill available = 1;
+}
+
+// Available language options
+message LanguageOptions {
+  repeated Language available = 1;
+}
+
+// Available fighting style options
+message FightingStyleOptions {
+  repeated FightingStyle available = 1;
+}
+
+// Available tool options
+message ToolOptions {
+  repeated Tool available = 1;
+}
 
 // Spell damage information
 message SpellDamage {

--- a/dnd5e/api/v1alpha1/enums.proto
+++ b/dnd5e/api/v1alpha1/enums.proto
@@ -237,7 +237,7 @@ enum EquipmentType {
 // D&D 5e weapons - maps to toolkit WeaponID constants
 enum Weapon {
   WEAPON_UNSPECIFIED = 0;
-  
+
   // Simple Melee Weapons
   WEAPON_CLUB = 1;
   WEAPON_DAGGER = 2;
@@ -249,13 +249,13 @@ enum Weapon {
   WEAPON_QUARTERSTAFF = 8;
   WEAPON_SICKLE = 9;
   WEAPON_SPEAR = 10;
-  
+
   // Simple Ranged Weapons
   WEAPON_LIGHT_CROSSBOW = 11;
   WEAPON_DART = 12;
   WEAPON_SHORTBOW = 13;
   WEAPON_SLING = 14;
-  
+
   // Martial Melee Weapons
   WEAPON_BATTLEAXE = 15;
   WEAPON_FLAIL = 16;
@@ -275,18 +275,18 @@ enum Weapon {
   WEAPON_WAR_PICK = 30;
   WEAPON_WARHAMMER = 31;
   WEAPON_WHIP = 32;
-  
+
   // Martial Ranged Weapons
   WEAPON_BLOWGUN = 33;
   WEAPON_HAND_CROSSBOW = 34;
   WEAPON_HEAVY_CROSSBOW = 35;
   WEAPON_LONGBOW = 36;
   WEAPON_NET = 37;
-  
+
   // Ammunition
   WEAPON_ARROWS_20 = 38;
   WEAPON_BOLTS_20 = 39;
-  
+
   // Category placeholders for choice requirements
   WEAPON_ANY_SIMPLE = 40;
   WEAPON_ANY_MARTIAL = 41;
@@ -296,25 +296,25 @@ enum Weapon {
 // D&D 5e armor - maps to toolkit ArmorID constants
 enum Armor {
   ARMOR_UNSPECIFIED = 0;
-  
+
   // Light Armor
   ARMOR_PADDED = 1;
   ARMOR_LEATHER = 2;
   ARMOR_STUDDED_LEATHER = 3;
-  
+
   // Medium Armor
   ARMOR_HIDE = 4;
   ARMOR_CHAIN_SHIRT = 5;
   ARMOR_SCALE_MAIL = 6;
   ARMOR_BREASTPLATE = 7;
   ARMOR_HALF_PLATE = 8;
-  
+
   // Heavy Armor
   ARMOR_RING_MAIL = 9;
   ARMOR_CHAIN_MAIL = 10;
   ARMOR_SPLINT = 11;
   ARMOR_PLATE = 12;
-  
+
   // Shield
   ARMOR_SHIELD = 13;
 }
@@ -322,18 +322,18 @@ enum Armor {
 // D&D 5e fighting styles - maps to toolkit FightingStyle constants
 enum FightingStyle {
   FIGHTING_STYLE_UNSPECIFIED = 0;
-  FIGHTING_STYLE_ARCHERY = 1;              // +2 to attack rolls with ranged weapons
-  FIGHTING_STYLE_DEFENSE = 2;              // +1 to AC while wearing armor
-  FIGHTING_STYLE_DUELING = 3;              // +2 damage with one-handed weapons
+  FIGHTING_STYLE_ARCHERY = 1; // +2 to attack rolls with ranged weapons
+  FIGHTING_STYLE_DEFENSE = 2; // +1 to AC while wearing armor
+  FIGHTING_STYLE_DUELING = 3; // +2 damage with one-handed weapons
   FIGHTING_STYLE_GREAT_WEAPON_FIGHTING = 4; // Reroll 1s and 2s on damage with two-handed
-  FIGHTING_STYLE_PROTECTION = 5;           // Impose disadvantage on attacks against allies
-  FIGHTING_STYLE_TWO_WEAPON_FIGHTING = 6;  // Add ability modifier to off-hand damage
+  FIGHTING_STYLE_PROTECTION = 5; // Impose disadvantage on attacks against allies
+  FIGHTING_STYLE_TWO_WEAPON_FIGHTING = 6; // Add ability modifier to off-hand damage
 }
 
 // D&D 5e tools - maps to toolkit ToolID constants
 enum Tool {
   TOOL_UNSPECIFIED = 0;
-  
+
   // Artisan's Tools
   TOOL_ALCHEMIST_SUPPLIES = 1;
   TOOL_BREWER_SUPPLIES = 2;
@@ -352,13 +352,13 @@ enum Tool {
   TOOL_TINKER_TOOLS = 15;
   TOOL_WEAVER_TOOLS = 16;
   TOOL_WOODCARVER_TOOLS = 17;
-  
+
   // Gaming Sets
   TOOL_DICE_SET = 18;
   TOOL_DRAGONCHESS_SET = 19;
   TOOL_PLAYING_CARD_SET = 20;
   TOOL_THREE_DRAGON_ANTE = 21;
-  
+
   // Musical Instruments
   TOOL_BAGPIPES = 22;
   TOOL_DRUM = 23;
@@ -370,7 +370,7 @@ enum Tool {
   TOOL_PAN_FLUTE = 29;
   TOOL_SHAWM = 30;
   TOOL_VIOL = 31;
-  
+
   // Other Tools
   TOOL_DISGUISE_KIT = 32;
   TOOL_FORGERY_KIT = 33;

--- a/dnd5e/api/v1alpha1/enums.proto
+++ b/dnd5e/api/v1alpha1/enums.proto
@@ -233,3 +233,151 @@ enum EquipmentType {
   EQUIPMENT_TYPE_MUSICAL_INSTRUMENT = 13;
   EQUIPMENT_TYPE_VEHICLE = 14;
 }
+
+// D&D 5e weapons - maps to toolkit WeaponID constants
+enum Weapon {
+  WEAPON_UNSPECIFIED = 0;
+  
+  // Simple Melee Weapons
+  WEAPON_CLUB = 1;
+  WEAPON_DAGGER = 2;
+  WEAPON_GREATCLUB = 3;
+  WEAPON_HANDAXE = 4;
+  WEAPON_JAVELIN = 5;
+  WEAPON_LIGHT_HAMMER = 6;
+  WEAPON_MACE = 7;
+  WEAPON_QUARTERSTAFF = 8;
+  WEAPON_SICKLE = 9;
+  WEAPON_SPEAR = 10;
+  
+  // Simple Ranged Weapons
+  WEAPON_LIGHT_CROSSBOW = 11;
+  WEAPON_DART = 12;
+  WEAPON_SHORTBOW = 13;
+  WEAPON_SLING = 14;
+  
+  // Martial Melee Weapons
+  WEAPON_BATTLEAXE = 15;
+  WEAPON_FLAIL = 16;
+  WEAPON_GLAIVE = 17;
+  WEAPON_GREATAXE = 18;
+  WEAPON_GREATSWORD = 19;
+  WEAPON_HALBERD = 20;
+  WEAPON_LANCE = 21;
+  WEAPON_LONGSWORD = 22;
+  WEAPON_MAUL = 23;
+  WEAPON_MORNINGSTAR = 24;
+  WEAPON_PIKE = 25;
+  WEAPON_RAPIER = 26;
+  WEAPON_SCIMITAR = 27;
+  WEAPON_SHORTSWORD = 28;
+  WEAPON_TRIDENT = 29;
+  WEAPON_WAR_PICK = 30;
+  WEAPON_WARHAMMER = 31;
+  WEAPON_WHIP = 32;
+  
+  // Martial Ranged Weapons
+  WEAPON_BLOWGUN = 33;
+  WEAPON_HAND_CROSSBOW = 34;
+  WEAPON_HEAVY_CROSSBOW = 35;
+  WEAPON_LONGBOW = 36;
+  WEAPON_NET = 37;
+  
+  // Ammunition
+  WEAPON_ARROWS_20 = 38;
+  WEAPON_BOLTS_20 = 39;
+  
+  // Category placeholders for choice requirements
+  WEAPON_ANY_SIMPLE = 40;
+  WEAPON_ANY_MARTIAL = 41;
+  WEAPON_ANY = 42;
+}
+
+// D&D 5e armor - maps to toolkit ArmorID constants
+enum Armor {
+  ARMOR_UNSPECIFIED = 0;
+  
+  // Light Armor
+  ARMOR_PADDED = 1;
+  ARMOR_LEATHER = 2;
+  ARMOR_STUDDED_LEATHER = 3;
+  
+  // Medium Armor
+  ARMOR_HIDE = 4;
+  ARMOR_CHAIN_SHIRT = 5;
+  ARMOR_SCALE_MAIL = 6;
+  ARMOR_BREASTPLATE = 7;
+  ARMOR_HALF_PLATE = 8;
+  
+  // Heavy Armor
+  ARMOR_RING_MAIL = 9;
+  ARMOR_CHAIN_MAIL = 10;
+  ARMOR_SPLINT = 11;
+  ARMOR_PLATE = 12;
+  
+  // Shield
+  ARMOR_SHIELD = 13;
+}
+
+// D&D 5e fighting styles - maps to toolkit FightingStyle constants
+enum FightingStyle {
+  FIGHTING_STYLE_UNSPECIFIED = 0;
+  FIGHTING_STYLE_ARCHERY = 1;              // +2 to attack rolls with ranged weapons
+  FIGHTING_STYLE_DEFENSE = 2;              // +1 to AC while wearing armor
+  FIGHTING_STYLE_DUELING = 3;              // +2 damage with one-handed weapons
+  FIGHTING_STYLE_GREAT_WEAPON_FIGHTING = 4; // Reroll 1s and 2s on damage with two-handed
+  FIGHTING_STYLE_PROTECTION = 5;           // Impose disadvantage on attacks against allies
+  FIGHTING_STYLE_TWO_WEAPON_FIGHTING = 6;  // Add ability modifier to off-hand damage
+}
+
+// D&D 5e tools - maps to toolkit ToolID constants
+enum Tool {
+  TOOL_UNSPECIFIED = 0;
+  
+  // Artisan's Tools
+  TOOL_ALCHEMIST_SUPPLIES = 1;
+  TOOL_BREWER_SUPPLIES = 2;
+  TOOL_CALLIGRAPHER_SUPPLIES = 3;
+  TOOL_CARPENTER_TOOLS = 4;
+  TOOL_CARTOGRAPHER_TOOLS = 5;
+  TOOL_COBBLER_TOOLS = 6;
+  TOOL_COOK_UTENSILS = 7;
+  TOOL_GLASSBLOWER_TOOLS = 8;
+  TOOL_JEWELER_TOOLS = 9;
+  TOOL_LEATHERWORKER_TOOLS = 10;
+  TOOL_MASON_TOOLS = 11;
+  TOOL_PAINTER_SUPPLIES = 12;
+  TOOL_POTTER_TOOLS = 13;
+  TOOL_SMITH_TOOLS = 14;
+  TOOL_TINKER_TOOLS = 15;
+  TOOL_WEAVER_TOOLS = 16;
+  TOOL_WOODCARVER_TOOLS = 17;
+  
+  // Gaming Sets
+  TOOL_DICE_SET = 18;
+  TOOL_DRAGONCHESS_SET = 19;
+  TOOL_PLAYING_CARD_SET = 20;
+  TOOL_THREE_DRAGON_ANTE = 21;
+  
+  // Musical Instruments
+  TOOL_BAGPIPES = 22;
+  TOOL_DRUM = 23;
+  TOOL_DULCIMER = 24;
+  TOOL_FLUTE = 25;
+  TOOL_LUTE = 26;
+  TOOL_LYRE = 27;
+  TOOL_HORN = 28;
+  TOOL_PAN_FLUTE = 29;
+  TOOL_SHAWM = 30;
+  TOOL_VIOL = 31;
+  
+  // Other Tools
+  TOOL_DISGUISE_KIT = 32;
+  TOOL_FORGERY_KIT = 33;
+  TOOL_HERBALISM_KIT = 34;
+  TOOL_NAVIGATOR_TOOLS = 35;
+  TOOL_POISONER_KIT = 36;
+  TOOL_THIEVES_TOOLS = 37;
+  TOOL_VEHICLES_LAND = 38;
+  TOOL_VEHICLES_WATER = 39;
+}


### PR DESCRIPTION
## Summary
- Added comprehensive proto enums that map to ALL toolkit typed constants
- Created new choice-related messages with type-safe enums
- Added GetRequirements and SubmitChoices RPCs for the new choice system

## Key Changes

### New Enums (matching toolkit constants)
- **Weapon**: All 42 weapons from toolkit (club, dagger, longsword, etc.)
- **Armor**: All 13 armor types from toolkit (leather, chain mail, plate, etc.)
- **FightingStyle**: All 6 fighting styles (archery, defense, dueling, etc.)
- **Tool**: All 39 tools (thieves' tools, herbalism kit, lute, etc.)

### New Choice Messages
- **EquipmentChoice/Option/Selection**: Type-safe equipment choices
- **ChoiceSubmission**: Unified submission with oneof for different types
- **CharacterRequirements**: What choices need to be made
- **Type-specific selections**: SkillSelection, LanguageSelection, etc.

### New RPCs
- **GetRequirements**: Get all required choices for a character
- **SubmitChoices**: Submit player choices with validation

## Rationale
As discussed, having an enum for every typed constant in the toolkit is a strength:
- Provides compile-time type safety for web/mobile clients
- Enables explicit conversion functions in handlers
- Allows validation and alerting for unknown values
- Prevents string typos across all clients

The numerous conversion functions needed are intentional - that's literally the handler's primary job: converting and validating at the API boundary.

## Testing
These proto changes will be tested when implementing the handler converters in rpg-api.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>