### PR TITLE
add enums for all char creation types

### DIFF
--- a/dnd5e/api/v1alpha1/character.proto
+++ b/dnd5e/api/v1alpha1/character.proto
@@ -214,7 +214,7 @@ message Character {
 
   // Class features and choices
   repeated CharacterFeature features = 22;
-  repeated string fighting_styles = 23;
+  repeated FightingStyle fighting_styles = 23;
 
   // Racial traits
   repeated CharacterFeature racial_traits = 24;
@@ -1337,7 +1337,7 @@ message ChoiceData {
     SkillList skills = 5;
     LanguageList languages = 6;
     AbilityScores ability_scores = 7;
-    string fighting_style = 8;
+    FightingStyle fighting_style = 8;
     EquipmentList equipment = 9;
     RaceChoice race = 10;
     ClassChoice class = 11;
@@ -1360,7 +1360,7 @@ message LanguageList {
 }
 
 message EquipmentList {
-  repeated string items = 1;
+  repeated EquipmentSelection items = 1;
 }
 
 message SpellList {
@@ -1424,9 +1424,11 @@ message EquipmentSelection {
     Weapon weapon = 1;
     Armor armor = 2;
     Tool tool = 3;
-    string other_equipment_id = 4; // For non-weapon/armor/tool items
+    Pack pack = 4;
+    Ammunition ammunition = 5;
+    string other_equipment_id = 6; // For items not yet enumerated
   }
-  int32 quantity = 5; // Default 1
+  int32 quantity = 7; // Default 1
 }
 
 // Submission for a choice made by the player

--- a/dnd5e/api/v1alpha1/enums.proto
+++ b/dnd5e/api/v1alpha1/enums.proto
@@ -381,3 +381,24 @@ enum Tool {
   TOOL_VEHICLES_LAND = 38;
   TOOL_VEHICLES_WATER = 39;
 }
+
+// D&D 5e equipment packs - maps to toolkit PackID constants
+enum Pack {
+  PACK_UNSPECIFIED = 0;
+  PACK_BURGLARS = 1;
+  PACK_DIPLOMATS = 2;
+  PACK_DUNGEONEERS = 3;
+  PACK_ENTERTAINERS = 4;
+  PACK_EXPLORERS = 5;
+  PACK_PRIESTS = 6;
+  PACK_SCHOLARS = 7;
+}
+
+// D&D 5e ammunition types
+enum Ammunition {
+  AMMUNITION_UNSPECIFIED = 0;
+  AMMUNITION_ARROWS_20 = 1;
+  AMMUNITION_BOLTS_20 = 2;
+  AMMUNITION_BLOWGUN_NEEDLES_50 = 3;
+  AMMUNITION_SLING_BULLETS_20 = 4;
+}


### PR DESCRIPTION
This pull request updates the D&D 5e character API to use more structured types for fighting styles and equipment, improving data consistency and extensibility. The changes primarily affect how fighting styles and equipment are represented in the protocol buffer definitions.

**Equipment and Fighting Style Type Improvements:**

* Changed `fighting_styles` in the `Character` message and `fighting_style` in `ChoiceData` from `string` to the new `FightingStyle` type, ensuring stronger type safety. [[1]](diffhunk://#diff-3f0c0962f6cf70256ee1a647d93f75f35209a6e0e1ac7f1f0263b498f9c79d83L217-R217) [[2]](diffhunk://#diff-3f0c0962f6cf70256ee1a647d93f75f35209a6e0e1ac7f1f0263b498f9c79d83L1340-R1340)
* Updated the `items` field in `EquipmentList` from a list of `string` to a list of `EquipmentSelection`, allowing more detailed equipment representation.

**EquipmentSelection Structure Enhancements:**

* Expanded `EquipmentSelection` to include new fields for `Pack` and `Ammunition`, and moved `other_equipment_id` to a new field number, supporting a wider range of equipment types.

**New Enumerations:**

* Added `Pack` and `Ammunition` enums to represent D&D 5e equipment packs and ammunition types, enabling explicit and structured references instead of relying on strings.