### PR TITLE
add spell info

### DIFF
--- a/dnd5e/api/v1alpha1/character.proto
+++ b/dnd5e/api/v1alpha1/character.proto
@@ -767,6 +767,19 @@ message SpellcastingInfo {
   int32 spell_slots_level_1 = 6;
 }
 
+// Information about a spell
+message SpellInfo {
+  // The spell enum value
+  Spell spell_id = 1;
+
+  // Display information
+  string name = 2;
+  string description = 3;
+
+  // Spell level (0 for cantrips, 1-9 for leveled spells)
+  int32 level = 4;
+}
+
 // Detailed background information for selection UI
 message BackgroundInfo {
   // The background enum value
@@ -1134,7 +1147,7 @@ message ListSpellsByLevelRequest {
 
 // Response with spell list
 message ListSpellsByLevelResponse {
-  repeated Spell spells = 1;
+  repeated SpellInfo spells = 1;
   string next_page_token = 2;
   int32 total_size = 3;
 }


### PR DESCRIPTION
This pull request introduces a new `SpellInfo` message to the API and updates the spell listing response to provide richer spell information. The main goal is to enhance the detail and usability of spell data returned by the API.

**API enhancements:**

* Added a new `SpellInfo` message, which includes the spell's enum value, name, description, and level, to provide more detailed information about each spell.
* Updated the `ListSpellsByLevelResponse` to return a list of `SpellInfo` objects instead of just the `Spell` enum, allowing clients to access more comprehensive spell details in a single response.