### PR TITLE
fix: Use proper proficiency category types in Proficiencies message

### DIFF
--- a/dnd5e/api/v1alpha1/character.proto
+++ b/dnd5e/api/v1alpha1/character.proto
@@ -264,14 +264,23 @@ message Proficiencies {
   // Saving throw proficiencies
   repeated Ability saving_throws = 2;
 
-  // Armor proficiencies - now using typed enums to match toolkit
-  repeated Armor armor = 3;
+  // Armor proficiency categories (light, medium, heavy, shields)
+  repeated ArmorProficiencyCategory armor_categories = 6;
 
-  // Weapon proficiencies - now using typed enums to match toolkit
-  repeated Weapon weapons = 4;
+  // Weapon proficiency categories (simple, martial)
+  repeated WeaponProficiencyCategory weapon_categories = 7;
 
-  // Tool proficiencies - now using typed enums to match toolkit
+  // Specific weapon proficiencies (for individual weapons like longsword)
+  repeated Weapon specific_weapons = 8;
+
+  // Tool proficiencies
   repeated Tool tools = 5;
+
+  // Deprecated: Use armor_categories instead
+  repeated Armor armor = 3 [deprecated = true];
+
+  // Deprecated: Use weapon_categories and specific_weapons instead
+  repeated Weapon weapons = 4 [deprecated = true];
 }
 
 // Character metadata


### PR DESCRIPTION
## Summary
- Fix type mismatch in Proficiencies message where item enums were used instead of proficiency category enums
- Add `armor_categories` (ArmorProficiencyCategory) for light/medium/heavy/shields proficiencies
- Add `weapon_categories` (WeaponProficiencyCategory) for simple/martial weapon proficiencies
- Add `specific_weapons` for individual weapon proficiencies (like longsword, rapier)
- Deprecate old `armor` and `weapons` fields that used incorrect types

## Background
The toolkit stores proficiencies as categories (e.g., "light armor", "simple weapons") not specific items (e.g., "leather armor", "longsword"). The Proficiencies message was incorrectly using `Armor` and `Weapon` enums which represent specific items, making it impossible to properly convert toolkit proficiency data.

This fixes the issue where proficiencies from issues #395 and #396 in rpg-toolkit couldn't be passed through the API to the web client.

## Test plan
- [ ] Proto builds successfully with `buf build`
- [ ] No breaking changes (old fields deprecated but not removed)
- [ ] Update rpg-api converters to use new fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)