### PR TITLE
deprecate(equipment): mark EQUIPMENT_SLOT_GLOVES as deprecated

### DIFF
--- a/dnd5e/api/v1alpha1/character.proto
+++ b/dnd5e/api/v1alpha1/character.proto
@@ -1195,7 +1195,9 @@ enum EquipmentSlot {
   EQUIPMENT_SLOT_ARMOR = 3;
   EQUIPMENT_SLOT_HELMET = 4;
   EQUIPMENT_SLOT_BOOTS = 5;
-  EQUIPMENT_SLOT_GLOVES = 6;
+  // Deprecated: Gloves slot is not used in current game mechanics.
+  // Will be removed in a future version.
+  EQUIPMENT_SLOT_GLOVES = 6 [deprecated = true];
   EQUIPMENT_SLOT_CLOAK = 7;
   EQUIPMENT_SLOT_AMULET = 8;
   EQUIPMENT_SLOT_RING_1 = 9;


### PR DESCRIPTION
## Summary
- Mark `EQUIPMENT_SLOT_GLOVES` as deprecated using protobuf `[deprecated = true]` option
- Add comment explaining the deprecation reason

## Context
Gloves slot is not used in current game mechanics and has no corresponding slot in the toolkit's `InventorySlot` constants. The slot will be removed in a future version.

## Related
- rpg-api#271 - Migration to toolkit's character.EquipmentSlots
- rpg-api#272 - PR implementing the migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)