### PR TITLE
feat: add Room field to StartCombatResponse

### DIFF
--- a/dnd5e/api/v1alpha1/encounter.proto
+++ b/dnd5e/api/v1alpha1/encounter.proto
@@ -394,6 +394,7 @@ message StartCombatRequest {
 // StartCombatResponse returns the initial combat state
 message StartCombatResponse {
   CombatState combat_state = 1;
+  Room room = 2; // Room with entity positions for rendering
 }
 
 // LeaveEncounterRequest removes a player from the encounter


### PR DESCRIPTION
## Summary
- Add `Room room = 2` field to `StartCombatResponse`

This allows clients to render the combat grid with entity positions when combat starts, rather than requiring a separate call to fetch room data.

## Test plan
- [ ] CI builds protos successfully
- [ ] rpg-api can import updated protos and return room in StartCombat

🤖 Generated with [Claude Code](https://claude.com/claude-code)