### PR TITLE
[Encounter Stream 1/3] Add GetEncounterState RPC for load-then-stream pattern

### DIFF
--- a/dnd5e/api/v1alpha1/encounter.proto
+++ b/dnd5e/api/v1alpha1/encounter.proto
@@ -170,6 +170,45 @@ message GetCombatStateResponse {
   CombatState combat_state = 2;
 }
 
+// GetEncounterStateRequest retrieves the full encounter snapshot
+// Used for the load-then-stream pattern to sync state before processing events
+message GetEncounterStateRequest {
+  string encounter_id = 1;
+  string player_id = 2;
+}
+
+// MonsterCombatState contains monster HP information for rendering
+// Entity positions are in Room.entities, this provides combat stats
+message MonsterCombatState {
+  string monster_id = 1;
+  string monster_name = 2;
+  int32 current_hit_points = 3;
+  int32 max_hit_points = 4;
+}
+
+// GetEncounterStateResponse returns a full snapshot of the encounter
+// Includes everything needed to render the current state without events
+message GetEncounterStateResponse {
+  // Encounter metadata
+  string encounter_id = 1;
+  EncounterState state = 2;
+
+  // Lobby state (populated in WAITING state)
+  repeated PartyMember party = 3;
+  string join_code = 4;
+  string host_id = 5;
+
+  // Combat state (populated in ACTIVE state)
+  CombatState combat_state = 6;
+  Room room = 7;
+  repeated MonsterCombatState monsters = 8;
+
+  // Event synchronization
+  // ULID of the most recent event - used for client-side filtering
+  // Client should ignore events with event_id <= last_event_id
+  string last_event_id = 9;
+}
+
 // ============================================================================
 // MOVEMENT
 // ============================================================================
@@ -686,7 +725,12 @@ service EncounterService {
   // === State Retrieval ===
 
   // GetCombatState retrieves current state (for reconnection/refresh)
+  // Deprecated: Use GetEncounterState for full snapshot with event sync
   rpc GetCombatState(GetCombatStateRequest) returns (GetCombatStateResponse);
+
+  // GetEncounterState retrieves full encounter snapshot for load-then-stream pattern
+  // Returns complete state including last_event_id for client-side event filtering
+  rpc GetEncounterState(GetEncounterStateRequest) returns (GetEncounterStateResponse);
 
   // === Combat Actions ===
 


### PR DESCRIPTION
## Summary

Adds full encounter snapshot RPC to fix the race condition where clients miss events (especially monster-first turns) when subscribing to the stream after combat starts.

Closes #93

## Changes

### New Messages

**GetEncounterStateRequest**
```protobuf
message GetEncounterStateRequest {
  string encounter_id = 1;
  string player_id = 2;
}
```

**MonsterCombatState** - Monster HP for rendering (positions are in Room.entities)
```protobuf
message MonsterCombatState {
  string monster_id = 1;
  string monster_name = 2;
  int32 current_hit_points = 3;
  int32 max_hit_points = 4;
}
```

**GetEncounterStateResponse** - Full snapshot with event sync
```protobuf
message GetEncounterStateResponse {
  string encounter_id = 1;
  EncounterState state = 2;           // WAITING, ACTIVE, etc.
  repeated PartyMember party = 3;     // Lobby + combat
  string join_code = 4;               // Lobby
  string host_id = 5;                 // Lobby
  CombatState combat_state = 6;       // Combat
  Room room = 7;                      // Combat
  repeated MonsterCombatState monsters = 8;  // Combat
  string last_event_id = 9;           // ULID for event filtering
}
```

### New RPC

```protobuf
rpc GetEncounterState(GetEncounterStateRequest) returns (GetEncounterStateResponse);
```

## How It Works

The `last_event_id` (ULID) enables client-side event filtering:

```
1. Client subscribes to stream (events buffer)
2. Client calls GetEncounterState → snapshot + lastEventId
3. Client renders from snapshot
4. Client processes buffered events where event.id > lastEventId
```

## Test Plan

- [ ] Proto compiles with `buf build`
- [ ] Proto lints with `buf lint`
- [ ] Generated code works in rpg-api (next PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)