### PR TITLE
feat: Add ActionType enum for feature action economy

### DIFF
--- a/dnd5e/api/v1alpha1/character.proto
+++ b/dnd5e/api/v1alpha1/character.proto
@@ -78,8 +78,9 @@ message CharacterFeature {
   string id = 1;
   string name = 2;
   string description = 3;
-  string source = 4; // "class", "race", "background", etc
+  string source = 4; // Full ref format: "dnd5e:classes:barbarian"
   int32 level = 5; // Level when gained (0 for racial/background)
+  ActionType action_type = 6; // Action economy cost to activate
 }
 
 // Types of class resources in D&D 5e

--- a/dnd5e/api/v1alpha1/enums.proto
+++ b/dnd5e/api/v1alpha1/enums.proto
@@ -671,6 +671,15 @@ enum FeatureId {
   FEATURE_ID_STARRY_FORM_ARCHER = 7; // Stars Druid bonus action attack
 }
 
+// ActionType represents the action economy cost of activating a feature
+enum ActionType {
+  ACTION_TYPE_UNSPECIFIED = 0;
+  ACTION_TYPE_ACTION = 1;
+  ACTION_TYPE_BONUS_ACTION = 2;
+  ACTION_TYPE_REACTION = 3;
+  ACTION_TYPE_FREE = 4; // No action cost (Sneak Attack, Reckless Attack declaration)
+}
+
 // MonsterActionType categorizes monster actions for behavior decisions
 // Maps to toolkit's monster.ActionType constants
 enum MonsterActionType {


### PR DESCRIPTION
## Summary

- Add `ActionType` enum with values for action, bonus action, reaction, and free
- Add `action_type` field to `CharacterFeature` message
- Update `source` field comment to document full ref format (`dnd5e:classes:barbarian`)

## Changes

**enums.proto:**
```proto
enum ActionType {
  ACTION_TYPE_UNSPECIFIED = 0;
  ACTION_TYPE_ACTION = 1;
  ACTION_TYPE_BONUS_ACTION = 2;
  ACTION_TYPE_REACTION = 3;
  ACTION_TYPE_FREE = 4;
}
```

**character.proto:**
```proto
message CharacterFeature {
  // ... existing fields ...
  ActionType action_type = 6;
}
```

## Context

The web app needs to know the action cost for features to properly display them grouped by action type (actions, bonus actions, etc.) in the combat panel.

Closes #94

## Related

- rpg-api#318: Populate action_type when building character features
- rpg-dnd5e-web#271: Refactor combat panel to use generic feature components

🤖 Generated with [Claude Code](https://claude.com/claude-code)