### PR TITLE
feat: Add enum IDs to Condition and CharacterFeature

### DIFF
--- a/dnd5e/api/v1alpha1/character.proto
+++ b/dnd5e/api/v1alpha1/character.proto
@@ -75,7 +75,8 @@ service CharacterService {
 
 // Character feature (class features, racial traits, etc)
 message CharacterFeature {
-  string id = 1;
+  // Feature identifier (maps to toolkit feature ref)
+  FeatureId id = 1;
   string name = 2;
   string description = 3;
   string source = 4; // Full ref format: "dnd5e:classes:barbarian"

--- a/dnd5e/api/v1alpha1/common.proto
+++ b/dnd5e/api/v1alpha1/common.proto
@@ -99,6 +99,9 @@ message Condition {
 
   // Any additional notes
   string notes = 4;
+
+  // Condition identifier (maps to toolkit condition ref)
+  ConditionId id = 5;
 }
 
 // Validation warning (non-blocking)


### PR DESCRIPTION
## Summary
- Add `ConditionId id` field to `Condition` message (field 5) - non-breaking addition
- Change `CharacterFeature.id` from `string` to `FeatureId` enum (field 1) - **breaking change**

## Why
The API wasn't properly converting condition/feature data from the toolkit because it was looking for string fields that don't exist in the toolkit's JSON structure. The toolkit uses `ref` fields that map to these enums.

This allows the converter to:
1. Parse the `ref` field from toolkit JSON
2. Map it to the appropriate enum (`ConditionId` or `FeatureId`)
3. Send strongly-typed identifiers to the UI

## Breaking Change Note
`CharacterFeature.id` changing from `string` to `FeatureId` is intentional - the string was never being used correctly anyway.

## Test plan
- [ ] CI passes proto compilation
- [ ] Update rpg-api converters to populate the new enum fields
- [ ] Verify UI receives correct condition/feature IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)