### PR TITLE
feat(enums): Add missing class-based condition IDs

### DIFF
--- a/dnd5e/api/v1alpha1/enums.proto
+++ b/dnd5e/api/v1alpha1/enums.proto
@@ -656,6 +656,11 @@ enum ConditionId {
   CONDITION_ID_FIGHTING_STYLE_ARCHERY = 8;
   CONDITION_ID_FIGHTING_STYLE_DEFENSE = 9;
   CONDITION_ID_FIGHTING_STYLE_PROTECTION = 10;
+  // Class-based passive conditions
+  CONDITION_ID_UNARMORED_DEFENSE = 11;
+  CONDITION_ID_IMPROVED_CRITICAL = 12;
+  CONDITION_ID_MARTIAL_ARTS = 13;
+  CONDITION_ID_UNARMORED_MOVEMENT = 14;
 }
 
 // FeatureId identifies class/racial features that directly deal damage when activated


### PR DESCRIPTION
## Summary

Adds condition IDs for class-based passive conditions that were present in the toolkit refs but missing from the proto enums.

## New Condition IDs

| ID | Value | Description |
|----|-------|-------------|
| CONDITION_ID_UNARMORED_DEFENSE | 11 | Barbarian/Monk AC calculation |
| CONDITION_ID_IMPROVED_CRITICAL | 12 | Champion Fighter crits on 19-20 |
| CONDITION_ID_MARTIAL_ARTS | 13 | Monk unarmed strike damage |
| CONDITION_ID_UNARMORED_MOVEMENT | 14 | Monk movement bonus |

## Context

These conditions come from `refs.Conditions` in the toolkit:
- `refs.Conditions.UnarmoredDefense()`
- `refs.Conditions.ImprovedCritical()`
- `refs.Conditions.MartialArts()`
- `refs.Conditions.UnarmoredMovement()`

Without these IDs, conditions are passed to the frontend with `id: 0` (UNSPECIFIED), making it harder for the UI to handle them appropriately.

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)