### PR TITLE
feat: Add updated_room field to TurnEndedEvent

### DIFF
--- a/dnd5e/api/v1alpha1/encounter.proto
+++ b/dnd5e/api/v1alpha1/encounter.proto
@@ -607,6 +607,7 @@ message FeatureActivatedEvent {
 message TurnEndedEvent {
   TurnChangeEvent turn_change = 1;
   CombatState combat_state = 2;
+  Room updated_room = 3; // Room with updated entity positions after turn
 }
 
 // MonsterTurnCompletedEvent is sent when a monster finishes its turn


### PR DESCRIPTION
## Summary

- Adds `Room updated_room = 3` field to `TurnEndedEvent` message
- Enables multiplayer sync of entity positions after turn changes
- Matches pattern used by `MonsterTurnCompletedEvent`

## Changes

```protobuf
message TurnEndedEvent {
  TurnChangeEvent turn_change = 1;
  CombatState combat_state = 2;
  Room updated_room = 3; // NEW - Room with updated entity positions
}
```

## Test plan

- [ ] CI passes (buf lint/format)
- [ ] Generated code compiles

Fixes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)