### PR TITLE
feat: Add GetEncounterHistory RPC for late join/reconnect

### DIFF
--- a/dnd5e/api/v1alpha1/encounter.proto
+++ b/dnd5e/api/v1alpha1/encounter.proto
@@ -209,9 +209,9 @@ message GetEncounterStateResponse {
   string last_event_id = 9;
 }
 
-// GetCombatHistoryRequest retrieves historical combat events for an encounter
-// Used by late joiners to populate combat log before streaming new events
-message GetCombatHistoryRequest {
+// GetEncounterHistoryRequest retrieves historical events for an encounter
+// Used by late joiners to populate event log before streaming new events
+message GetEncounterHistoryRequest {
   string encounter_id = 1;
   // Get events up to this ID (from GetEncounterState.last_event_id)
   // If empty, returns all events
@@ -221,8 +221,8 @@ message GetCombatHistoryRequest {
   int32 limit = 3;
 }
 
-// GetCombatHistoryResponse returns historical combat events
-message GetCombatHistoryResponse {
+// GetEncounterHistoryResponse returns historical encounter events
+message GetEncounterHistoryResponse {
   // Events in chronological order
   repeated EncounterEvent events = 1;
   // True if more events exist beyond the limit
@@ -755,9 +755,9 @@ service EncounterService {
   // Returns complete state including last_event_id for client-side event filtering
   rpc GetEncounterState(GetEncounterStateRequest) returns (GetEncounterStateResponse);
 
-  // GetCombatHistory retrieves historical combat events for late join/reconnect
-  // Returns events up to the specified event ID for combat log population
-  rpc GetCombatHistory(GetCombatHistoryRequest) returns (GetCombatHistoryResponse);
+  // GetEncounterHistory retrieves historical events for late join/reconnect
+  // Returns events up to the specified event ID for event log population
+  rpc GetEncounterHistory(GetEncounterHistoryRequest) returns (GetEncounterHistoryResponse);
 
   // === Combat Actions ===
 


### PR DESCRIPTION
## Summary
- Add `GetEncounterHistoryRequest` message with encounter_id, up_to_event_id, and limit
- Add `GetEncounterHistoryResponse` message with events, has_more, and last_event_id  
- Add `GetEncounterHistory` RPC to EncounterService in State Retrieval section

## Context
Part of [Event Source 5/6] - enables clients to fetch event history for late join/reconnect scenarios before streaming new events.

Named "EncounterHistory" (not "CombatHistory") since events cover the full encounter lifecycle: lobby, combat, connection, and dungeon exploration events.

## Integration Flow
```
Late joiner connects:
1. GetEncounterState() → snapshot + last_event_id
2. GetEncounterHistory(up_to_event_id) → historical events for event log
3. StreamEncounterEvents() → live events (filter out events ≤ last_event_id)
```

## Test plan
- [x] buf format passes
- [x] buf build passes

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)