### PR TITLE
feat: Add AttackHand enum for two-weapon fighting

### DIFF
--- a/dnd5e/api/v1alpha1/encounter.proto
+++ b/dnd5e/api/v1alpha1/encounter.proto
@@ -320,6 +320,7 @@ message AttackRequest {
   string attacker_id = 2;
   string target_id = 3;
   string weapon_id = 4; // Optional, uses default weapon if not specified
+  AttackHand attack_hand = 5; // Which hand is attacking (for two-weapon fighting)
 }
 
 // ============================================================================

--- a/dnd5e/api/v1alpha1/enums.proto
+++ b/dnd5e/api/v1alpha1/enums.proto
@@ -793,3 +793,10 @@ enum DungeonState {
   DUNGEON_STATE_FAILED = 3; // Party wiped (TPK)
   DUNGEON_STATE_ABANDONED = 4; // Players left the dungeon
 }
+
+// AttackHand specifies which hand is making the attack for two-weapon fighting
+enum AttackHand {
+  ATTACK_HAND_UNSPECIFIED = 0; // Default to main hand behavior
+  ATTACK_HAND_MAIN = 1; // Main hand attack (uses action)
+  ATTACK_HAND_OFF = 2; // Off-hand attack (uses bonus action, TWF rules apply)
+}


### PR DESCRIPTION
## Summary

Closes #112

Adds proto definitions to support two-weapon fighting bonus action attacks. This is Phase 1 of KirkDiggler/rpg-api#359.

## Changes

- Add `AttackHand` enum to `enums.proto`:
  - `ATTACK_HAND_UNSPECIFIED` (0) - defaults to main hand behavior
  - `ATTACK_HAND_MAIN` (1) - main hand attack (uses action)
  - `ATTACK_HAND_OFF` (2) - off-hand attack (uses bonus action, TWF rules apply)

- Add `attack_hand` field to `AttackRequest` message

## Context

- **API Issue**: https://github.com/KirkDiggler/rpg-api/issues/359
- **Toolkit PR**: https://github.com/KirkDiggler/rpg-toolkit/pull/510 (merged as v0.38.1)

The toolkit now has `AttackHand` type in `combat.ResolveAttackInput`. These proto definitions allow clients to specify off-hand attacks.

## Test plan

- [x] buf format passes
- [x] buf build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)