### PR TITLE
feat: Add dungeon config to StartCombatRequest

### DIFF
--- a/dnd5e/api/v1alpha1/encounter.proto
+++ b/dnd5e/api/v1alpha1/encounter.proto
@@ -511,6 +511,10 @@ message SetReadyResponse {
 // StartCombatRequest initiates combat (host only, all players must be ready)
 message StartCombatRequest {
   string encounter_id = 1;
+  // Dungeon configuration (host sets these in lobby)
+  DungeonTheme theme = 2;
+  DungeonDifficulty difficulty = 3;
+  DungeonLength length = 4;
 }
 
 // StartCombatResponse returns the initial combat state


### PR DESCRIPTION
## Summary
- Add `theme`, `difficulty`, and `length` fields to `StartCombatRequest`
- Enables multiplayer lobby flow to specify dungeon configuration when starting combat
- Matches the solo path (`DungeonStartRequest`) which already has these fields

## Test plan
- [x] Proto builds cleanly (`buf build`)
- [x] Format applied (`buf format -w`)

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)