### PR TITLE
feat: Add walls field to Room message

### DIFF
--- a/dnd5e/api/v1alpha1/encounter.proto
+++ b/dnd5e/api/v1alpha1/encounter.proto
@@ -50,6 +50,8 @@ message Room {
   // Entities placed in the room - map of entity ID to their placement data
   // Matches toolkit's map[string]EntityPlacement structure
   map<string, EntityPlacement> entities = 7;
+  // Wall segments in the room (perimeter + internal tactical walls)
+  repeated .api.v1alpha1.Wall walls = 8;
 }
 
 // DoorInfo represents a connection point between rooms in a dungeon


### PR DESCRIPTION
## Summary
- Add `repeated Wall walls` field to the `Room` message in encounter.proto
- Supports rendering of perimeter and internal tactical walls generated by the dungeon component

## Context
This is part of the dungeon theme refactor work in rpg-api. The dungeon generator now creates:
- Perimeter walls (room boundaries with door openings)
- Internal walls (tactical patterns like pillar grids, chokepoints, cover clusters)

The walls need to be exposed in the API response for the client to render them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)