### PR TITLE
feat(encounter): add room_origin to OpenDoorResponse

### DIFF
--- a/dnd5e/api/v1alpha1/encounter.proto
+++ b/dnd5e/api/v1alpha1/encounter.proto
@@ -134,6 +134,9 @@ message OpenDoorResponse {
   repeated DoorInfo doors = 7;
   // Updated dungeon state (may transition to VICTORIOUS if boss room cleared)
   DungeonState dungeon_state = 8;
+  // Room origin in dungeon-absolute coordinates (for floor hex rendering)
+  // Used by clients to position the revealed room's floor hexes in the unified coordinate system
+  .api.v1alpha1.Position room_origin = 9;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Adds `room_origin` field (field 9) to `OpenDoorResponse` message
- Enables clients to position revealed room floor hexes in the unified dungeon coordinate system
- The first room has origin (0,0,0) but subsequent rooms need their calculated origin

## Related Issue
Part of issue #399 (Unified Dungeon Coordinate System) in rpg-api

## Test Plan
- [ ] CI passes (buf lint, buf breaking)
- [ ] rpg-api integration after proto update

🤖 Generated with [Claude Code](https://claude.com/claude-code)