### PR TITLE
refactor(encounter): move origin to Room message

### DIFF
--- a/dnd5e/api/v1alpha1/encounter.proto
+++ b/dnd5e/api/v1alpha1/encounter.proto
@@ -62,6 +62,10 @@ message Room {
   map<string, EntityPlacement> entities = 7;
   // Wall segments in the room (perimeter + internal tactical walls)
   repeated .api.v1alpha1.Wall walls = 8;
+  // Room origin in dungeon-absolute coordinates
+  // Used to position floor hexes in the unified coordinate system
+  // First room has origin (0,0,0), subsequent rooms are offset based on door alignment
+  .api.v1alpha1.Position origin = 9;
 }
 
 // DoorInfo represents a connection point between rooms in a dungeon
@@ -134,9 +138,6 @@ message OpenDoorResponse {
   repeated DoorInfo doors = 7;
   // Updated dungeon state (may transition to VICTORIOUS if boss room cleared)
   DungeonState dungeon_state = 8;
-  // Room origin in dungeon-absolute coordinates (for floor hex rendering)
-  // Used by clients to position the revealed room's floor hexes in the unified coordinate system
-  .api.v1alpha1.Position room_origin = 9;
 }
 
 // ============================================================================


### PR DESCRIPTION
closes: https://github.com/KirkDiggler/rpg-api-protos/issues/124

## Summary
- Move `origin` field from `OpenDoorResponse` to `Room` message (field 9)
- This ensures origin is available wherever `Room` is used:
  - `OpenDoorResponse.room`
  - `RoomRevealedEvent.room`
  - Any future `Room` usage

## Related Issue
Part of issue #399 (Unified Dungeon Coordinate System) in rpg-api

## Test Plan
- [ ] CI passes (buf lint, buf breaking)
- [ ] rpg-api integration after proto update

🤖 Generated with [Claude Code](https://claude.com/claude-code)