### PR TITLE
feat: Add two-level action economy protos

### DIFF
--- a/dnd5e/api/v1alpha1/encounter.proto
+++ b/dnd5e/api/v1alpha1/encounter.proto
@@ -156,12 +156,45 @@ message InitiativeEntry {
 // TurnState tracks resources available during a turn
 message TurnState {
   string entity_id = 1;
-  int32 movement_used = 2;
-  int32 movement_max = 3;
-  bool action_used = 4;
-  bool bonus_action_used = 5;
-  bool reaction_available = 6;
+  int32 movement_used = 2 [deprecated = true]; // Use action_economy.movement_remaining
+  int32 movement_max = 3 [deprecated = true]; // Use action_economy.movement_max
+  bool action_used = 4 [deprecated = true]; // Use action_economy.standard_action_available
+  bool bonus_action_used = 5 [deprecated = true]; // Use action_economy.bonus_action_available
+  bool reaction_available = 6 [deprecated = true]; // Use action_economy.reaction_available
   .api.v1alpha1.Position position = 7;
+
+  // New action economy system - tracks all combat resources
+  ActionEconomy action_economy = 8;
+}
+
+// ActionEconomy tracks all combat resources available during a turn
+// This replaces the individual boolean/int fields in TurnState
+message ActionEconomy {
+  // Movement capacity in feet (base speed, DASH adds to it)
+  int32 movement_remaining = 1;
+  // Maximum movement for this turn (base + any bonuses like DASH)
+  int32 movement_max = 2;
+
+  // Attack capacity granted by ATTACK ability
+  // Starts at 0, ATTACK grants 1 (or more with Extra Attack)
+  int32 attacks_remaining = 3;
+
+  // Standard action availability (consumed by ATTACK, DASH, DODGE, etc.)
+  bool standard_action_available = 4;
+  // Bonus action availability (consumed by off-hand attack, Flurry of Blows, etc.)
+  bool bonus_action_available = 5;
+  // Reaction availability (consumed by opportunity attacks, etc.)
+  bool reaction_available = 6;
+
+  // Off-hand attack capacity (granted by two-weapon fighting after main attack)
+  int32 off_hand_attacks_remaining = 7;
+  // Flurry strikes remaining (granted by Flurry of Blows)
+  int32 flurry_strikes_remaining = 8;
+
+  // Whether disengage is active (no opportunity attacks this turn)
+  bool disengage_active = 9;
+  // Whether dodge is active (attacks against have disadvantage)
+  bool dodge_active = 10;
 }
 
 // CombatState represents the complete state of combat
@@ -416,6 +449,90 @@ message AttackResponse {
 }
 
 // ============================================================================
+// TWO-LEVEL ACTION ECONOMY
+// ============================================================================
+
+// ActivateCombatAbilityRequest activates a combat ability (ATTACK, DASH, DODGE, etc.)
+// This consumes action economy resources and grants capacity to execute actions
+message ActivateCombatAbilityRequest {
+  string encounter_id = 1;
+  string entity_id = 2;
+  CombatAbilityId ability_id = 3;
+
+  // Optional target for abilities that need one (HELP)
+  string target_id = 4;
+}
+
+// ActivateCombatAbilityResponse returns the result of ability activation
+message ActivateCombatAbilityResponse {
+  bool success = 1;
+  string error = 2;
+
+  // Updated action economy after activation
+  ActionEconomy action_economy = 3;
+
+  // What capacity was granted (for UI feedback)
+  // e.g., "Granted 2 attacks" for Fighter with Extra Attack
+  string granted_capacity = 4;
+
+  // Full combat state update
+  CombatState combat_state = 5;
+}
+
+// StrikeInput contains parameters for executing a strike action
+message StrikeInput {
+  string target_id = 1;
+  string weapon_id = 2; // Optional, uses equipped weapon if not specified
+}
+
+// MoveInput contains parameters for executing a move action
+message MoveInput {
+  repeated .api.v1alpha1.Position path = 1; // Each step in order
+}
+
+// ExecuteActionRequest executes an action that consumes granted capacity
+message ExecuteActionRequest {
+  string encounter_id = 1;
+  string entity_id = 2;
+  ActionId action_id = 3;
+
+  // Action-specific input
+  oneof input {
+    StrikeInput strike = 10;
+    MoveInput move = 11;
+  }
+}
+
+// MoveResult contains the outcome of a move action
+message MoveResult {
+  .api.v1alpha1.Position final_position = 1;
+  int32 movement_used = 2;
+  string stop_reason = 3; // "completed", "trap triggered", etc.
+}
+
+// ExecuteActionResponse returns the result of action execution
+message ExecuteActionResponse {
+  bool success = 1;
+  string error = 2;
+
+  // Updated action economy after execution
+  ActionEconomy action_economy = 3;
+
+  // Action-specific result
+  oneof result {
+    AttackResult strike_result = 10;
+    MoveResult move_result = 11;
+  }
+
+  // Full state updates
+  CombatState combat_state = 4;
+  Room updated_room = 5;
+
+  // For strike actions: was an off-hand attack granted?
+  GrantedAction granted_action = 6;
+}
+
+// ============================================================================
 // MONSTER TURN RESULTS
 // ============================================================================
 
@@ -593,13 +710,17 @@ message EncounterEvent {
     PlayerReadyEvent player_ready = 12;
     CombatStartedEvent combat_started = 13;
 
-    // Combat events
+    // Combat events (legacy)
     MovementCompletedEvent movement_completed = 20;
     AttackResolvedEvent attack_resolved = 21;
     FeatureActivatedEvent feature_activated = 22;
     TurnEndedEvent turn_ended = 23;
     MonsterTurnCompletedEvent monster_turn_completed = 24;
     CombatEndedEvent combat_ended = 25;
+
+    // Combat events (new action economy)
+    CombatAbilityActivatedEvent combat_ability_activated = 26;
+    ActionExecutedEvent action_executed = 27;
 
     // Connection events
     PlayerDisconnectedEvent player_disconnected = 30;
@@ -699,6 +820,44 @@ message MonsterTurnCompletedEvent {
 // CombatEndedEvent is sent when combat ends (victory or defeat)
 message CombatEndedEvent {
   EncounterResult result = 1;
+}
+
+// CombatAbilityActivatedEvent is sent when an entity activates a combat ability
+message CombatAbilityActivatedEvent {
+  string entity_id = 1;
+  CombatAbilityId ability_id = 2;
+  // What capacity was granted (for UI/log display)
+  string granted_capacity = 3;
+  // Updated action economy after activation
+  ActionEconomy action_economy = 4;
+  // Full combat state update
+  CombatState combat_state = 5;
+}
+
+// ActionExecutedEvent is sent when an entity executes an action
+message ActionExecutedEvent {
+  string entity_id = 1;
+  ActionId action_id = 2;
+
+  // Action-specific result
+  oneof result {
+    AttackResult strike_result = 10;
+    MoveResult move_result = 11;
+  }
+
+  // Updated action economy after execution
+  ActionEconomy action_economy = 3;
+
+  // State updates
+  CombatState combat_state = 4;
+  Room updated_room = 5;
+
+  // For attack actions: target and updated state
+  string target_id = 6;
+  Character updated_target = 7; // If target took damage
+
+  // Was an additional action granted? (e.g., off-hand strike)
+  GrantedAction granted_action = 8;
 }
 
 // ============================================================================
@@ -819,17 +978,33 @@ service EncounterService {
   // Returns events up to the specified event ID for event log population
   rpc GetEncounterHistory(GetEncounterHistoryRequest) returns (GetEncounterHistoryResponse);
 
-  // === Combat Actions ===
+  // === Combat Actions (Legacy) ===
 
+  // Deprecated: Use ExecuteAction with ACTION_ID_MOVE instead.
   // MoveCharacter validates and executes movement along a path
-  rpc MoveCharacter(MoveCharacterRequest) returns (MoveCharacterResponse);
+  rpc MoveCharacter(MoveCharacterRequest) returns (MoveCharacterResponse) {
+    option deprecated = true;
+  }
 
   // EndTurn ends the current entity's turn
   rpc EndTurn(EndTurnRequest) returns (EndTurnResponse);
 
+  // Deprecated: Use ActivateCombatAbility + ExecuteAction instead.
   // Attack executes a melee or ranged attack
-  rpc Attack(AttackRequest) returns (AttackResponse);
+  rpc Attack(AttackRequest) returns (AttackResponse) {
+    option deprecated = true;
+  }
 
   // ActivateFeature activates a combat feature (e.g., Rage, Second Wind)
   rpc ActivateFeature(ActivateFeatureRequest) returns (ActivateFeatureResponse);
+
+  // === Combat Actions (Two-Level Action Economy) ===
+
+  // ActivateCombatAbility activates a combat ability (ATTACK, DASH, DODGE, etc.)
+  // This consumes action economy resources and grants capacity to execute actions
+  rpc ActivateCombatAbility(ActivateCombatAbilityRequest) returns (ActivateCombatAbilityResponse);
+
+  // ExecuteAction executes an action that consumes granted capacity
+  // Use after ActivateCombatAbility to perform strikes, moves, etc.
+  rpc ExecuteAction(ExecuteActionRequest) returns (ExecuteActionResponse);
 }

--- a/dnd5e/api/v1alpha1/enums.proto
+++ b/dnd5e/api/v1alpha1/enums.proto
@@ -844,3 +844,37 @@ enum ObstacleType {
   OBSTACLE_TYPE_BARREL = 61;
   OBSTACLE_TYPE_TABLE = 62;
 }
+
+// CombatAbilityId identifies standard combat abilities that consume action economy
+// Activating an ability grants capacity to execute specific actions
+enum CombatAbilityId {
+  COMBAT_ABILITY_ID_UNSPECIFIED = 0;
+
+  // Standard actions (consume standard action)
+  COMBAT_ABILITY_ID_ATTACK = 1; // Grants attack capacity (1 strike, or more with Extra Attack)
+  COMBAT_ABILITY_ID_DASH = 2; // Grants extra movement capacity (doubles speed)
+  COMBAT_ABILITY_ID_DODGE = 3; // Grants dodging condition until next turn
+  COMBAT_ABILITY_ID_DISENGAGE = 4; // Grants free movement without opportunity attacks
+  COMBAT_ABILITY_ID_HELP = 5; // Grants advantage to an ally's next attack or check
+  COMBAT_ABILITY_ID_HIDE = 6; // Attempt to become hidden
+  COMBAT_ABILITY_ID_READY = 7; // Prepare an action for a trigger
+
+  // Bonus action abilities
+  COMBAT_ABILITY_ID_OFFHAND_ATTACK = 10; // Two-weapon fighting bonus action attack
+  COMBAT_ABILITY_ID_FLURRY_OF_BLOWS = 11; // Monk: 2 unarmed strikes for 1 ki
+}
+
+// ActionId identifies executable actions that consume granted capacity
+// Actions are executed after activating a combat ability
+enum ActionId {
+  ACTION_ID_UNSPECIFIED = 0;
+
+  // Movement actions
+  ACTION_ID_MOVE = 1; // Consume movement capacity to change position
+
+  // Attack actions
+  ACTION_ID_STRIKE = 2; // Execute a weapon attack (main hand)
+  ACTION_ID_OFF_HAND_STRIKE = 3; // Execute off-hand attack (two-weapon fighting)
+  ACTION_ID_FLURRY_STRIKE = 4; // Execute unarmed strike from Flurry of Blows
+  ACTION_ID_UNARMED_STRIKE = 5; // Execute unarmed strike (Martial Arts bonus action)
+}


### PR DESCRIPTION
## Summary

Implements the two-level action economy system for combat as designed in #127:

- **New Enums**: `CombatAbilityId` (ATTACK, DASH, DODGE, DISENGAGE, HELP, HIDE, READY, OFFHAND_ATTACK, FLURRY_OF_BLOWS) and `ActionId` (MOVE, STRIKE, OFF_HAND_STRIKE, FLURRY_STRIKE, UNARMED_STRIKE)
- **New Messages**: `ActionEconomy`, `ActivateCombatAbilityRequest/Response`, `ExecuteActionRequest/Response`, `StrikeInput`, `MoveInput`, `MoveResult`, `CombatAbilityActivatedEvent`, `ActionExecutedEvent`
- **Modified**: `TurnState` (deprecated old fields, added `action_economy`), `EncounterEvent` (added new events)
- **New RPCs**: `ActivateCombatAbility`, `ExecuteAction`
- **Deprecated RPCs**: `Attack`, `MoveCharacter`

## New Flow

```
ActivateCombatAbility(ATTACK) → grants attack capacity
ExecuteAction(STRIKE)         → consumes capacity, resolves attack
```

This replaces the direct `Attack` RPC approach, enabling proper support for Extra Attack, two-weapon fighting, Flurry of Blows, etc.

## Test plan

- [x] `buf format -w` passes
- [x] `buf lint` passes  
- [x] `buf build` passes

Closes #127

🤖 Generated with [Claude Code](https://claude.ai/code)