### PR TITLE
feat: Add AvailableAbility and AvailableAction messages

### DIFF
--- a/dnd5e/api/v1alpha1/encounter.proto
+++ b/dnd5e/api/v1alpha1/encounter.proto
@@ -197,6 +197,32 @@ message ActionEconomy {
   bool dodge_active = 10;
 }
 
+// AvailableAbility represents a combat ability with its current availability status
+// Used by UI to render ability buttons with proper enabled/disabled state
+message AvailableAbility {
+  // Which ability this represents
+  CombatAbilityId ability_id = 1;
+  // Display name for UI
+  string name = 2;
+  // Whether the ability can be activated right now
+  bool can_use = 3;
+  // Explanation if can_use is false (e.g., "no actions remaining")
+  string reason = 4;
+}
+
+// AvailableAction represents an executable action with its current availability status
+// Used by UI to render action buttons based on granted capacity
+message AvailableAction {
+  // Which action this represents
+  ActionId action_id = 1;
+  // Display name for UI
+  string name = 2;
+  // Whether the action can be executed right now
+  bool can_use = 3;
+  // Explanation if can_use is false (e.g., "no attacks remaining")
+  string reason = 4;
+}
+
 // CombatState represents the complete state of combat
 message CombatState {
   string encounter_id = 1;
@@ -477,6 +503,14 @@ message ActivateCombatAbilityResponse {
 
   // Full combat state update
   CombatState combat_state = 5;
+
+  // Current availability of all combat abilities after this activation
+  // UI should refresh ability buttons based on this list
+  repeated AvailableAbility available_abilities = 6;
+
+  // Current availability of all actions after this activation
+  // UI should refresh action buttons based on this list
+  repeated AvailableAction available_actions = 7;
 }
 
 // StrikeInput contains parameters for executing a strike action
@@ -530,6 +564,14 @@ message ExecuteActionResponse {
 
   // For strike actions: was an off-hand attack granted?
   GrantedAction granted_action = 6;
+
+  // Current availability of all combat abilities after this action
+  // UI should refresh ability buttons based on this list
+  repeated AvailableAbility available_abilities = 7;
+
+  // Current availability of all actions after this action
+  // UI should refresh action buttons based on this list
+  repeated AvailableAction available_actions = 8;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Add proto messages to expose what abilities and actions a player can take at any given moment.

- **AvailableAbility**: Combat abilities (Attack, Dash, Dodge, etc.) with availability status
- **AvailableAction**: Executable actions (Strike, Move, FlurryStrike, etc.) with availability status

## The Problem

The toolkit's TurnManager has `GetAvailableAbilities()` and `GetAvailableActions()` methods that return what a player can do, including:
- `can_use`: Whether it can be used right now
- `reason`: Why not (e.g., "no actions remaining")

Without these proto messages, the web UI would have to derive availability from `ActionEconomy` fields:
```typescript
// Without: UI must derive this
if (economy.flurryStrikesRemaining > 0) {
  actions.push(ActionId.FLURRY_STRIKE);
}
```

This duplicates logic the toolkit already knows.

## The Solution

Include availability in every combat response:

```json
{
  "success": true,
  "action_economy": { "flurry_strikes_remaining": 2 },
  "available_actions": [
    { "action_id": "FLURRY_STRIKE", "name": "Flurry Strike", "can_use": true },
    { "action_id": "STRIKE", "name": "Strike", "can_use": false, "reason": "no attacks remaining" }
  ]
}
```

Web just renders what it's told.

## Changes

**New Messages:**
- `AvailableAbility`: ability_id, name, can_use, reason
- `AvailableAction`: action_id, name, can_use, reason

**Updated Responses:**
- `ActivateCombatAbilityResponse`: +available_abilities, +available_actions
- `ExecuteActionResponse`: +available_abilities, +available_actions

## Test plan

- [ ] `buf build` passes
- [ ] `buf lint` passes
- [ ] Generated code compiles in downstream repos

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)