### PR TITLE
ci: enforce buf breaking with breaking-change-approved override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,14 @@ jobs:
         run: buf format --diff --exit-code
       
       - name: Breaking change detection
-        if: github.event_name == 'pull_request'
-        continue-on-error: true
+        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'breaking-change-approved')
         run: buf breaking --against "https://github.com/${{ github.repository }}.git#branch=main"
+
+      - name: Breaking change override notice
+        if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'breaking-change-approved')
+        run: |
+          echo "::warning::buf breaking skipped — PR carries 'breaking-change-approved' label."
+          echo "::warning::Per docs/how-to/breaking-change-workflow.md, this is acceptable for alpha packages with explicit reviewer ack, or when a version bump (e.g. v1alpha1→v1alpha2) is the chosen migration path."
 
   generate-and-test:
     runs-on: ubuntu-latest

--- a/docs/architecture/components/environment-service.md
+++ b/docs/architecture/components/environment-service.md
@@ -58,8 +58,8 @@ service.
 ## What it would cost to delete
 
 - A breaking change at the file level (`buf breaking: use: [FILE]`).
-  Once `buf breaking` becomes blocking (issue #139), this service must
-  be deleted as part of the same PR or with explicit waiver.
+  `buf breaking` is blocking in CI; a deletion PR will need the
+  `breaking-change-approved` label since this is alpha-package code.
 - Generated TypeScript and Go consumers won't be affected — there
   aren't any.
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -54,7 +54,7 @@ PR opened
     ▼
 buf lint            (blocking)
 buf format --diff   (blocking)
-buf breaking        (continue-on-error: true — ADVISORY ONLY, see violation below)
+buf breaking        (blocking; PR may carry `breaking-change-approved` label to skip)
     │
     ▼
 PR merged to main
@@ -115,23 +115,27 @@ rpg-api's orchestrator. Tracked as **issue #138** (rpg-api-protos board).
 ### Rule 2: `buf breaking` is authoritative, not advisory
 
 A breaking change in this repo is a runtime break in either consumer. The
-schema check exists to prevent that. CI must enforce it.
+schema check exists to prevent that. CI enforces it.
 
-**Violation: `buf breaking` runs with `continue-on-error: true`.**
-`.github/workflows/ci.yml:31`:
+**Enforcement (since issue #139):** `.github/workflows/ci.yml` runs
+`buf breaking` as a blocking step on PRs. To intentionally land a breaking
+change — typically an alpha-package edit per
+[breaking-change-workflow.md](../how-to/breaking-change-workflow.md) — apply
+the **`breaking-change-approved`** label to the PR. The label flips the
+breaking step into a skipped + warning state and adds a CI annotation noting
+the override.
 
 ```yaml
 - name: Breaking change detection
-  if: github.event_name == 'pull_request'
-  continue-on-error: true        # ← defeats the check
+  if: github.event_name == 'pull_request' &&
+      !contains(github.event.pull_request.labels.*.name, 'breaking-change-approved')
   run: buf breaking --against ...
 ```
 
-A PR that introduces a breaking change reports a yellow x but merges anyway.
-The rest of the CI discipline (`buf lint` clean, `buf format --diff` clean,
-careful `reserved` use in PR #136) demonstrates the team knows the rules. CI
-just doesn't enforce the most important one. Tracked as **issue #139**. This
-is the highest-leverage one-line fix on the board.
+The override is intentional: alpha packages permit breaking changes, but
+each one requires explicit reviewer acknowledgment via the label, not a
+silent merge with a yellow x. Stable (v1+) services should bump the package
+version (`v1`→`v2`) instead of using the override.
 
 ### Rule 3: Deprecated fields are retired in the same release as their replacement
 
@@ -249,8 +253,9 @@ review. Reconciliation tracked as part of **issue #140**.
 - Proto file edits on feature branches.
 - `buf format -w` clean.
 - `buf lint` clean.
-- `buf breaking` clean against main (advisory today, blocking once #139
-  lands).
+- `buf breaking` clean against main, OR PR carries
+  `breaking-change-approved` label (alpha-only override; v1+ should bump
+  package version instead).
 
 **What this repo produces:**
 - `gen/go` consumed by `rpg-api` via `go.mod`:

--- a/docs/how-to/breaking-change-workflow.md
+++ b/docs/how-to/breaking-change-workflow.md
@@ -45,15 +45,21 @@ Non-breaking (safe):
 - Marking a field `[deprecated = true]` or an RPC `option deprecated
   = true` (these are advisory, not wire-affecting).
 
-## Today's CI gap
+## CI enforcement
 
-`.github/workflows/ci.yml:31` runs `buf breaking` with
-`continue-on-error: true`. **The check is advisory, not blocking.**
-A PR with a breaking change merges with a yellow x.
+`.github/workflows/ci.yml` runs `buf breaking` against `main` on every PR
+as a **blocking** step. A PR with an unintended breaking change fails CI
+and cannot merge.
 
-This is **issue #139** — the highest-leverage one-line fix on the
-board. Until that fix lands, treat `buf breaking` as if it were
-blocking when run locally; don't rely on CI.
+To intentionally land a breaking change, apply the
+**`breaking-change-approved`** label to the PR. The workflow then skips
+the breaking step and emits a CI annotation noting the override. Use this
+for alpha-package edits where breakage is part of the migration plan;
+v1+ services should bump the package version (`v1`→`v2`) instead.
+
+The check still runs locally; verify with `buf breaking --against
+"https://github.com/KirkDiggler/rpg-api-protos.git#branch=main"` before
+pushing.
 
 ## The PR #136 worked example
 
@@ -177,9 +183,12 @@ afterthought.
 - **Skipping `reserved` because "no one's using that tag anyway."**
   Future you, or another contributor, will reuse that tag and create
   a silent break. `reserved` is cheap.
-- **Bypassing CI's breaking check.** Today CI is advisory; locally
-  run the check and respect it. When CI becomes blocking (issue #139),
-  there will be no `--no-verify` equivalent for `buf breaking`.
+- **Bypassing CI's breaking check via the label without justification.**
+  The `breaking-change-approved` label is for migrations whose plan is
+  documented (in the PR description, in `rpg-project/ideas/`, or in a
+  linked design doc). Slapping the label on to silence CI without a
+  written rationale is the anti-pattern; the label is a deliberate
+  acknowledgment, not a `--no-verify` shortcut.
 
 ## When breaking is unavoidable: bump the version
 
@@ -202,7 +211,7 @@ appropriate for "I want to rename one field."
 - [run-buf-checks-locally.md](run-buf-checks-locally.md) — running
   `buf breaking` before pushing
 - [overview.md Rule 2](../architecture/overview.md#rule-2-buf-breaking-is-authoritative-not-advisory)
-  — the ci.yml issue (#139)
+  — the enforcement rule and override label policy
 - [overview.md Rule 3](../architecture/overview.md#rule-3-deprecated-fields-are-retired-in-the-same-release-as-their-replacement)
   — the deprecation discipline this workflow enforces
 - PR #136 in rpg-api-protos — the worked example

--- a/docs/how-to/consumer-integration.md
+++ b/docs/how-to/consumer-integration.md
@@ -172,8 +172,9 @@ boundary. See [breaking-change-workflow.md](breaking-change-workflow.md).
 
 - **Consumer pinned to old SDK uses removed field.** Compile-time
   break in rpg-api (Go), runtime break in rpg-dnd5e-web (TS proto
-  decode error). Mitigated by `buf breaking` (advisory today, blocking
-  per issue #139) and pre-merge consumer migration.
+  decode error). Mitigated by `buf breaking` (blocking in CI; PR can
+  carry `breaking-change-approved` for intentional breaks) and
+  pre-merge consumer migration.
 - **Consumer pinned to old SDK calls deprecated RPC.** Works (the RPC
   is still implemented today even when proto-deprecated) until the
   RPC is removed. Then unimplemented error at runtime.

--- a/docs/how-to/run-buf-checks-locally.md
+++ b/docs/how-to/run-buf-checks-locally.md
@@ -7,10 +7,11 @@ confidence: high — verified by running each command on docs/honest-status-snap
 
 # Run buf checks locally
 
-CI runs three buf checks. Two are blocking, one is currently advisory
-(see [overview.md Rule 2](../architecture/overview.md#rule-2-buf-breaking-is-authoritative-not-advisory)
-— issue #139 will make it blocking). Run all three locally before
-pushing.
+CI runs three buf checks; all three are blocking. The breaking-change
+check has a labeled override (`breaking-change-approved`) for intentional
+breaks — see
+[overview.md Rule 2](../architecture/overview.md#rule-2-buf-breaking-is-authoritative-not-advisory).
+Run all three locally before pushing.
 
 ## Prerequisites
 
@@ -34,7 +35,8 @@ buf lint
 buf format --diff --exit-code      # check (exits non-zero if changes needed)
 buf format -w                       # write fixes (run before commit)
 
-# 3. Breaking-change detection — currently advisory in CI.
+# 3. Breaking-change detection — blocking; PR may carry
+#    'breaking-change-approved' label to intentionally skip in CI.
 buf breaking --against "https://github.com/KirkDiggler/rpg-api-protos.git#branch=main"
 ```
 
@@ -101,9 +103,10 @@ If all five clean, push.
 - **`buf format`** — keeps PR diffs small. A formatting churn diff hides
   the actual change.
 - **`buf breaking`** — the contract guarantee. A breaking change here
-  is a runtime break in rpg-api or rpg-dnd5e-web. Today the check is
-  advisory in CI (`continue-on-error: true`). Run it locally; don't
-  rely on CI to catch it for you.
+  is a runtime break in rpg-api or rpg-dnd5e-web. CI enforces this
+  blocking, with the `breaking-change-approved` label as the only
+  override path. Run it locally too — failing on a push is slower than
+  catching it before the push.
 - **`buf generate`** — protos that fail to generate Go/TS won't ship.
   Catching here saves a CI cycle.
 

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -223,16 +223,20 @@ The deduction is for type-name collisions (`Room`, `Entity`,
 are technically fine in protobuf (different packages) but trip up
 generated TypeScript imports and code review.
 
-### Breaking-change discipline — B
+### Breaking-change discipline — A-
 
 - The repo uses `breaking: use: [FILE]` (per-file breaking detection).
-- CI runs `buf breaking` against `main` on PRs but with
-  `continue-on-error: true` — i.e. **non-blocking**. A breaking change
-  can land if humans don't catch it. For a contract repo that publishes
-  to BSR + npm + Go modules, this is the single biggest risk.
+- CI runs `buf breaking` against `main` on PRs as a **blocking** step
+  (since issue #139 / 2026-05-03). Intentional breaking changes apply the
+  `breaking-change-approved` label to skip the check; the workflow emits
+  a CI annotation noting the override.
 - The work in PR #136 demonstrates the team knows how to retire fields
-  correctly (`reserved` both number and name). The discipline exists in
-  practice; CI just doesn't enforce it.
+  correctly (`reserved` both number and name). The discipline now lives in
+  CI as well as in practice.
+- Held back from A by the dual-shape live coexistence (`EncounterStateData`
+  + legacy fields per Rule 1) — discipline is enforced at the wire level
+  but not yet at the "no two parallel shapes once a migration completes"
+  level.
 
 ### Deprecation path — C+
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -217,10 +217,11 @@ of which is canonical; the comment is the only signal.
 
 - `buf lint` clean as of 2026-05-02.
 - `buf format --diff --exit-code` clean.
-- `buf breaking` runs in CI on PRs with `continue-on-error: true` —
-  i.e. breaking detection is **advisory only**, not blocking. Worth
-  noting because the proto repo is the contract layer; a missed breaking
-  change here is a runtime break in either consumer.
+- `buf breaking` runs in CI on PRs as a **blocking** step. To intentionally
+  land a breaking change, apply the `breaking-change-approved` label to the
+  PR; the workflow then skips the breaking check and emits a CI annotation
+  noting the override. See
+  [breaking-change-workflow.md](how-to/breaking-change-workflow.md).
 - `buf.gen.yaml` includes `protocolbuffers/cpp` + `grpc/cpp` plugins
   even though no UE consumer exists in this workspace. CI generates the
   C++ output anyway.
@@ -258,8 +259,6 @@ Your read of where we are. See [quality.md](quality.md) for grade + rationale.
   shapes coexist in `GetEncounterStateResponse`.
 - **Remove deprecated RPCs** (`Attack`, `MoveCharacter`, `DungeonStart`,
   `GetCombatState`) from the service after consumers migrate.
-- **Make `buf breaking` blocking** in CI (currently `continue-on-error:
-  true`). The contract layer should not be advisory about breakage.
 - **Reconcile duplicate names** (`Room`, `Entity`, `EntitySize`,
   `DiceRoll`, `ValidationResult`). Either consolidate or rename to
   remove ambiguity.


### PR DESCRIPTION
## Summary

- Removes `continue-on-error: true` from the buf breaking CI step — breaking changes now block CI.
- Adds a label-based override: PRs carrying `breaking-change-approved` skip the breaking step and emit a CI annotation noting the override.
- Created the `breaking-change-approved` label on this repo (red, with description).
- Updates 7 docs that previously framed this as "issue #139 will fix": overview Rule 2, status.md, quality.md (B → A-), the three how-to guides, and environment-service.md.

Closes #139. First Wave 1 P0 of [Chapter 1: Architecture Honesty](https://github.com/users/KirkDiggler/projects/11).

## Why label-based override (not auto-exempt for alpha)

Two paths considered:
- `breaking.ignore_unstable_packages: true` — alpha packages auto-exempt. Rejected: silently disables the gate; loses the heads-up value of `buf breaking` even on alpha.
- Label override — every breaking change requires explicit acknowledgment. Matches `docs/how-to/breaking-change-workflow.md` policy ("alpha allows breaking via explicit ack; v1+ should bump version").

The label is a deliberate ack, not a `--no-verify` shortcut.

## Test plan

- [ ] CI on this PR is green (no proto changes; should be a no-op for the breaking step itself).
- [ ] Manual verification (suggested follow-up): open a deliberately-breaking test PR; confirm CI fails. Add the `breaking-change-approved` label; confirm the breaking step is skipped and the warning annotation appears.
- [ ] Wave 2 issue #143 (Position int32) will be the first real exercise of this gate — that PR carries the label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)