### PR TITLE
refactor: delete unused dnd5e.api.v1alpha1.DiceRoll (collision resolution)

### DIFF
--- a/dnd5e/api/v1alpha1/common.proto
+++ b/dnd5e/api/v1alpha1/common.proto
@@ -41,21 +41,6 @@ message ValidationError {
   string code = 3;
 }
 
-// Dice notation for various game mechanics
-message DiceRoll {
-  // Number of dice
-  int32 count = 1;
-
-  // Die size (4, 6, 8, 10, 12, 20, 100)
-  int32 size = 2;
-
-  // Modifier to add/subtract
-  int32 modifier = 3;
-
-  // String representation (e.g., "1d20+5")
-  string notation = 4;
-}
-
 // Modifier with a source for tracking
 message Modifier {
   // The ability or skill being modified

--- a/docs/architecture/components/dice-service.md
+++ b/docs/architecture/components/dice-service.md
@@ -1,7 +1,7 @@
 ---
 name: DiceService
 description: Generic dice rolling service with entity+context grouping; consumed for ability score rolls
-updated: 2026-05-02
+updated: 2026-05-04
 confidence: high — verified by reading api/v1alpha1/dice.proto end-to-end
 ---
 
@@ -81,19 +81,10 @@ int32 modifier = 8;               // applied modifier
 
 None. This service is the cleanest in the repo.
 
-The one issue is **Rule 6 (naming consistency): `DiceRoll` collision.**
-`api.v1alpha1.DiceRoll` (this file, line 49) and
-`dnd5e.api.v1alpha1.DiceRoll` (`common.proto:45`) share the message
-name despite different shapes:
-
-- `api.v1alpha1.DiceRoll` — a roll *result* with rolled dice values.
-- `dnd5e.api.v1alpha1.DiceRoll` — a roll *notation* (count, size,
-  modifier, "1d20+5").
-
-Different roles, different fields, identical name. Generated
-TypeScript code disambiguates by import path, but humans don't. When
-either is touched next, rename to `DiceRollResult` /
-`DiceRollNotation` (or similar).
+The previous `DiceRoll` name collision with `dnd5e.api.v1alpha1.DiceRoll`
+was resolved by deleting the unused dnd5e copy (issue #141, 2026-05-04).
+`api.v1alpha1.DiceRoll` is now the only `DiceRoll` message in the
+contract layer.
 
 ## Confidence and what's not verified
 

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -1,7 +1,7 @@
 ---
 name: rpg-api-protos data model
 description: Common message types, envelopes, error and pagination patterns, and known shape collisions
-updated: 2026-05-02
+updated: 2026-05-04
 confidence: high — verified by reading every .proto and grepping field reuse across files
 ---
 
@@ -75,17 +75,19 @@ Used by `dnd5e.api.v1alpha1.Room.walls` (encounter.proto:130). The
 encounter service imports `api.v1alpha1.Wall` rather than redefining
 it — good reuse.
 
-### Ability scores, dice, modifiers, conditions (`dnd5e/api/v1alpha1/common.proto`)
+### Ability scores, modifiers, conditions (`dnd5e/api/v1alpha1/common.proto`)
 
 ```proto
 message AbilityScores { strength, dexterity, constitution, intelligence, wisdom, charisma; }
-message DiceRoll { count, size, modifier, notation; }    // notation form
 message Modifier { target, value, source, type; }
 message Resource { name, current, maximum, refresh_on; } // hit dice, spell slots, etc.
 message Condition { name, source, duration, notes, ConditionId id, bytes condition_data; }
 message ValidationError { field, message, code; }
 message ValidationWarning { field, message, type; }
 ```
+
+For dice, see `api.v1alpha1.DiceRoll` (the result form, in `dice.proto`)
+— there is no notation-form message in the dnd5e package.
 
 `Condition.condition_data` (line 106) is `bytes` carrying toolkit-owned
 JSON. The pattern: enum identifies the condition; toolkit owns the

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -30,7 +30,7 @@ rpg-api-protos/
   dnd5e/api/v1alpha1/
     character.proto             # CharacterService — live
     encounter.proto             # EncounterService — live
-    common.proto                # AbilityScores, DiceRoll, Modifier, Resource, Condition, ValidationResult, SourceRef
+    common.proto                # AbilityScores, Modifier, Resource, Condition, ValidationResult, SourceRef
     enums.proto                 # Race, Class, Skill, Spell, etc.
     choices.proto               # Choice, ChoiceSubmission, ChoiceData
     equipment_types.proto       # Equipment, WeaponData, ArmorData, GearData
@@ -230,7 +230,7 @@ match it.
 - Enums: `<TYPE>_<UPPER_SNAKE>` with `_UNSPECIFIED = 0` ✓ (every enum)
 - Request/response: `<Verb><Subject>Request` / `Response` ✓
 
-The deduction is for **type-name collisions across packages.** Five names
+The deduction is for **type-name collisions across packages.** Four names
 are reused in 2+ places with different shapes:
 
 | Name | Locations | Status |
@@ -238,9 +238,10 @@ are reused in 2+ places with different shapes:
 | `Room` | `api.v1alpha1.Room` (`room_common.proto:176`); `dnd5e.api.v1alpha1.Room` (`encounter.proto:111`) | Both populated; only the dnd5e one is live |
 | `Entity` / `EntityPlacement` / `EntityState` | `api.v1alpha1.Entity` (generic, `room_common.proto:33`); `dnd5e.api.v1alpha1.EntityPlacement` (encounter.proto:18); `dnd5e.api.v1alpha1.EntityState` (encounter.proto:45) | Live: dnd5e versions; generic Entity not consumed |
 | `EntitySize` | `dnd5e.api.v1alpha1.EntitySize` (`enums.proto:818`); `sandbox.api.v1alpha1.EntitySize` (`sandbox_common.proto:73`) | Same six values, different fully-qualified names |
-| `DiceRoll` | `api.v1alpha1.DiceRoll` (`dice.proto:49`, a roll *result*); `dnd5e.api.v1alpha1.DiceRoll` (`common.proto:45`, a roll *notation*) | Different roles, identical name |
 | `ValidationResult` | `api.v1alpha1.ValidationResult` (`room_common.proto:216`, generic); `dnd5e.api.v1alpha1.ValidationResult` (`common.proto:122`, three-tier draft system) | Different shapes, identical name |
 | `Wall` | `api.v1alpha1.Wall` (`room_common.proto:104`); `sandbox.api.v1alpha1.WallSegment` (different shape) | Live: api.v1alpha1.Wall via encounter Room |
+
+(`DiceRoll` was previously in this list; the unused `dnd5e.api.v1alpha1.DiceRoll` was deleted in issue #141, 2026-05-04.)
 
 Technically valid in protobuf (different packages = different
 fully-qualified types). Trips up generated TypeScript imports and code

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -1,7 +1,7 @@
 ---
 name: rpg-api-protos quality scorecard
 description: Per-service grade with rationale — a graded scorecard the janitor will update over time
-updated: 2026-05-02
+updated: 2026-05-04
 confidence: low-medium — first draft grades from a read-through of every .proto file plus grep against rpg-api / rpg-dnd5e-web; expect Kirk to adjust
 ---
 
@@ -87,10 +87,9 @@ Strengths:
 
 Small, focused, well-named. Three RPCs (`RollDice`, `GetRollSession`,
 `ClearRollSession`) over a sensible entity+context grouping. Used by
-rpg-api. The only nitpick: `api.v1alpha1.DiceRoll` (a roll *result* with
-dice values) shares its name with `dnd5e.api.v1alpha1.DiceRoll` (a roll
-*notation*). Different packages, identical message name — confusing
-when both appear in a generated TS client.
+rpg-api. The previous `DiceRoll` name collision with
+`dnd5e.api.v1alpha1.DiceRoll` was resolved by deleting the unused
+dnd5e copy (issue #141, 2026-05-04).
 
 ## Live shared types
 
@@ -122,9 +121,6 @@ carries both an enum id and a `bytes condition_data` for toolkit-owned
 JSON.
 
 Drag:
-- `DiceRoll` here is the notation form; `api.DiceService` has its own
-  `DiceRoll` for results. Same name, different shapes, no hint at the
-  proto level that they're related.
 - `ValidationResult` here is the rich 3-tier draft validation;
   `api.v1alpha1.ValidationResult` (room_common) is a generic
   is-valid-or-not. Same name, different shapes.
@@ -219,7 +215,7 @@ candidate for deletion.**
   (consistent across all live services)
 
 The deduction is for type-name collisions (`Room`, `Entity`,
-`EntitySize`, `DiceRoll`, `ValidationResult` exist in 2+ places) which
+`EntitySize`, `ValidationResult` exist in 2+ places) which
 are technically fine in protobuf (different packages) but trip up
 generated TypeScript imports and code review.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -160,11 +160,6 @@ now.
   `sandbox.api.v1alpha1.EntitySize` — same six values, different fully-
   qualified names. Either consolidate to a shared one in `api/v1alpha1`
   or delete the sandbox copy when the package goes.
-- **Two `DiceRoll` messages.** `api.v1alpha1.DiceRoll` (in `dice.proto`,
-  rich roll result with rolled dice and dropped values) and
-  `dnd5e.api.v1alpha1.DiceRoll` (in `common.proto`, just notation +
-  count + size + modifier). Different roles (result vs. notation) but
-  same name — confusing.
 - **Two `ValidationResult` messages.** `api.v1alpha1.ValidationResult`
   (in `room_common.proto`, generic) and
   `dnd5e.api.v1alpha1.ValidationResult` (in `common.proto`, character
@@ -239,7 +234,7 @@ Your read of where we are. See [quality.md](quality.md) for grade + rationale.
 | `dnd5e/choices.proto` | Medium — works; submission shape has dual paths (generic `selection_ids` + deprecated `oneof`) that are not enforceable at the schema level |
 | `dnd5e/enums.proto` | Medium-high — comprehensive; some enums (`Spell`, `MonsterType`, `FeatureId`, `ConditionId`) grow per-feature with no deprecation discipline yet |
 | `dnd5e/equipment_types.proto` | Medium-high — small, focused, clean |
-| `dnd5e/common.proto` | Medium — solid building blocks; `DiceRoll` name collides with `api.DiceService.DiceRoll`; `ValidationResult` name collides with `api.ValidationResult` |
+| `dnd5e/common.proto` | Medium — solid building blocks; `ValidationResult` name collides with `api.ValidationResult` |
 | `api/room_common.proto` | Medium-low — generic shapes that aren't used by live consumers; risk of being kept "for the future" indefinitely |
 
 ## Upcoming work (not yet planned in detail)
@@ -253,8 +248,8 @@ Your read of where we are. See [quality.md](quality.md) for grade + rationale.
 - **Remove deprecated RPCs** (`Attack`, `MoveCharacter`, `DungeonStart`,
   `GetCombatState`) from the service after consumers migrate.
 - **Reconcile duplicate names** (`Room`, `Entity`, `EntitySize`,
-  `DiceRoll`, `ValidationResult`). Either consolidate or rename to
-  remove ambiguity.
+  `ValidationResult`). Either consolidate or rename to remove
+  ambiguity. (`DiceRoll` collision resolved 2026-05-04 — issue #141.)
 
 ## Related references
 


### PR DESCRIPTION
## Summary

- Deletes the unused `dnd5e.api.v1alpha1.DiceRoll` message from `dnd5e/api/v1alpha1/common.proto`. Resolves the long-standing name collision with `api.v1alpha1.DiceRoll` (the live dice-result message).
- The dnd5e copy was defined but **referenced zero times** in proto, rpg-api Go, or rpg-dnd5e-web TS (verified by grep).

Closes #141. Wave 1 P1 of [Chapter 1: Architecture Honesty](https://github.com/users/KirkDiggler/projects/11). **First exercise of the `breaking-change-approved` label** shipped in PR #144.

## Why deletion (not rename)

The issue suggested renaming to `DiceNotation`. Per Kirk 2026-05-04: "no use for it so we remove it. when we need it or similar we will have a fresh take on it." Deletion is the cleaner cut — resolves the collision AND satisfies Rule 4 (no proto unused for >1 release).

## Why the label

`buf breaking` correctly flags this:
\`\`\`
dnd5e/api/v1alpha1/common.proto:1:1:Previously present message "DiceRoll" was deleted from file.
\`\`\`
Per docs/how-to/breaking-change-workflow.md: alpha packages permit breaking changes via the `breaking-change-approved` label. This is the first PR to actually use it.

## Doc updates

5 docs updated to reflect the resolution: `status.md`, `quality.md`, `architecture/overview.md` (collision table trimmed from 5 → 4 entries), `architecture/components/dice-service.md`, `architecture/data-model.md`. Front-matter dates bumped to 2026-05-04.

## Test plan

- [x] `buf lint` / `buf format --diff --exit-code` clean
- [x] `buf generate` produces `gen/go` + `gen/ts` cleanly
- [x] No remaining `DiceRoll` references in dnd5e protos
- [x] Zero consumer references to the deleted message in rpg-api Go or rpg-dnd5e-web TS
- [ ] CI: lint + format + generate-and-test pass; breaking step shows the override warning annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)