### PR TITLE
feat(api/v1alpha1): Position fields float64 → int32

### DIFF
--- a/api/v1alpha1/room_common.proto
+++ b/api/v1alpha1/room_common.proto
@@ -5,11 +5,15 @@ package api.v1alpha1;
 // Common types shared across all room generation services
 // Provides universal spatial concepts and entity structures
 
-// Universal position coordinates for all grid systems
+// Universal position coordinates for all grid systems.
+// Integer cube-coordinate space: X+Y+Z=0 invariant for hex grids; X/Y for
+// square grids with Z=0. The previous double signature caused int↔float64
+// casts at every consumer boundary; see rpg-project/ideas/coordinate-types/
+// for the full motivation.
 message Position {
-  double x = 1;
-  double y = 2;
-  double z = 3; // Optional for future 3D support
+  int32 x = 1;
+  int32 y = 2;
+  int32 z = 3;
 }
 
 // Grid type enumeration for different RPG systems


### PR DESCRIPTION
## Summary
- `api.v1alpha1.Position` (`room_common.proto`) changes from `double x/y/z` to `int32 x/y/z`
- Closes #143
- Deliberate breaking change; uses the `breaking-change-approved` label override added in #144

## Why

Per `rpg-project/ideas/coordinate-types/design.md`, integer cube coordinates with the `X+Y+Z=0` invariant are the canonical coordinate space for the dungeon component. The double signature was the root cause of five coordinate-space bugs in Round 2 (paused PRs #459/#461/#463/#466/#467/#468). Changing the proto signature lets the rpg-api refactor (issue #471) use one type end-to-end with no casts.

## Versioning policy

In-place edit of v1alpha1 is allowed per the project versioning policy: alpha and beta packages explicitly allow breaking changes; v1+ would require a per-service version bump.

## buf breaking output (expected)

\`\`\`
api/v1alpha1/room_common.proto:14:3: Field "1" with name "x" on message "Position" changed type from "double" to "int32".
api/v1alpha1/room_common.proto:15:3: Field "2" with name "y" on message "Position" changed type from "double" to "int32".
api/v1alpha1/room_common.proto:16:3: Field "3" with name "z" on message "Position" changed type from "double" to "int32".
\`\`\`

These are the three intended changes. Applying the `breaking-change-approved` label so CI's breaking-change check passes.

## Test plan
- [x] `buf format -w` clean
- [x] `buf lint` passes
- [x] `buf breaking --against '.git#branch=main'` flags exactly the three intended field type changes
- [ ] CI: `breaking-change-approved` label gates the breaking check; build + lint + format all pass
- [ ] Wait for Copilot review
- [ ] On merge: CI publishes new SDK to `generated` branch; rpg-api branch (issue #471) does \`GOPROXY=direct go get .../rpg-api-protos/gen/go@generated\`

## Wave 2

This is the first PR of Wave 2 (coordinate types). After this lands, rpg-api #471 begins its three-phase refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)