### PR TITLE
ci: retrigger workflow on label changes (fixes breaking-change-approved override)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # Default pull_request types are [opened, synchronize, reopened]; adding
+    # labeled/unlabeled lets the breaking-change-approved override (see the
+    # "Breaking change detection" step) take effect when the label is applied
+    # *after* the PR is opened. Without this, applying the label later doesn't
+    # retrigger CI and the breaking step keeps failing on its first run.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Adds \`labeled, unlabeled\` to the workflow's \`pull_request\` trigger types
- Closes #148
- Wave 2 cleanup; surfaced live on PR #147

## The bug

The \`breaking-change-approved\` label override added in #144 has a UX flaw: it only works if the label is on the PR **at open time**. If you apply the label *after* opening, no workflow event fires (default \`pull_request\` types are \`[opened, synchronize, reopened]\` — \`labeled\` is not a default), and \`gh run rerun\` re-uses the original event payload with the label still missing.

## The fix

\`\`\`yaml
on:
  pull_request:
    branches: [main]
    types: [opened, synchronize, reopened, labeled, unlabeled]
\`\`\`

With this, applying or removing the label retriggers the workflow, and the label-aware \`if:\` condition on the breaking-change step re-evaluates correctly.

## How it surfaced

PR #147 (Position float64→int32) is Wave 2's first breaking-change PR. Opened, then applied \`breaking-change-approved\`, then watched CI fail because the label wasn't visible in the event payload. Worked around with an empty commit (fresh \`synchronize\` event picks up current label state). This PR removes the workaround for future breaking-change PRs.

## Test plan
- [x] Workflow YAML valid
- [ ] CI passes on this PR (no breaking change, label not needed)
- [ ] Once merged: next breaking-change PR can apply the label after open and CI re-fires automatically — this PR itself can't validate that path because it doesn't carry a breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)