### PR TITLE
feat(v1alpha2/encounter): add EntityDisappeared.last_known_position

### DIFF
--- a/dnd5e/api/v1alpha2/encounter/events.proto
+++ b/dnd5e/api/v1alpha2/encounter/events.proto
@@ -75,6 +75,13 @@ message EntityAppeared {
 message EntityDisappeared {
   string entity_id = 1;
   string reason = 2; // "left LOS", "invisibility cast"
+  // Per-viewer last-known position. Different viewers may have last seen the
+  // entity at different hexes (pass-through movement past two viewers in
+  // different positions), so the wire form is per-stream — the encounter
+  // server populates this for the specific subscriber receiving the event.
+  // Required for rendering "freeze marker at last-seen hex" without
+  // client-side game-state tracking.
+  Position last_known_position = 3;
 }
 
 message EntityMoved {


### PR DESCRIPTION
## Summary

Adds `Position last_known_position = 3` to `dnd5e.api.v1alpha2.encounter.EntityDisappeared`.

## Why

The toolkit's `EntityDisappearedEvent` (rpg-toolkit#629, merged in #630) emits a per-viewer last-known position via `PerPlayer map[PlayerID]core.Hex`. The wire shape today (`entity_id` + `reason` only) drops that position at the rpg-api ↔ web boundary.

Without it:
- rpg-dnd5e-web has to track per-entity last-seen-position client-side (violates `feedback_no_logic_in_web`)
- OR entities just vanish on disappear (degraded UX)
- OR they vanish at the server-canonical position which is wrong for pass-through (different viewers in different positions during the move have different last-known hexes)

## How rpg-api populates this per stream

The translator runs per-subscriber and already picks `evt.PerPlayer[viewer]` for other events. For EntityDisappeared:

```go
EntityDisappeared: &encounterv2pb.EntityDisappeared{
    EntityId:           string(e.Entity),
    Reason:             "left LOS",
    LastKnownPosition:  HexToPosition(e.PerPlayer[viewer]),
}
```

Per-viewer correctness preserved.

## Found via

Local exploration on rpg-api branch `explore/494-asymmetric-los` against rpg-toolkit#630. The asymmetric-LoS integration test (`TestMovementSlicePerViewerProjection_AsymmetricLoS`) exposed this — pass-through scenario worked end-to-end except for the dropped position. See rpg-api translator note at `internal/handlers/dnd5e/v2/encounter/translate.go::translateEntityDisappearedEvent` for the inline doc of the gap.

## Adjacent (not in this PR, but worth a thought)

`EntityAppeared` carries a full `Entity` message (id + position + type + display_name + hp + status_effects). The toolkit's `EntityAppearedEvent` provides only EntityID + Position. rpg-api today populates `Entity{id, position}` minimally and leaves richer fields for the client to look up from its snapshot. If the wire is meant to carry rich data inline, the toolkit event would need more fields too. Punt on this; raise as a separate issue if web slice 2 finds it inconvenient.

Closes #152.