### PR TITLE
feat(v1alpha2/encounter): reaction prompt + take_reaction + SetReactionReady (#156)

### DIFF
--- a/dnd5e/api/v1alpha2/encounter/events.proto
+++ b/dnd5e/api/v1alpha2/encounter/events.proto
@@ -51,7 +51,26 @@ message EncounterEvent {
     // Dialogue
     DialogueStarted dialogue_started = 50;
     DialogueEnded dialogue_ended = 51;
+
+    // Input prompts that arrive on the stream (rather than as the response of
+    // the calling RPC). Used by Wave 2.11d reaction prompts: when phase 1 of
+    // an attack publishes a ReactionTriggerEvent for a player reactor, the
+    // server pushes InputRequiredDelivered onto the reactor's per-viewer
+    // stream. The reactor responds via SubmitCheck{take_reaction}.
+    InputRequiredDelivered input_required_delivered = 60;
   }
+}
+
+// InputRequiredDelivered carries an InputRequired prompt that the server
+// is pushing onto a reactor's per-viewer stream. Wave 2.11d adds this so
+// reaction prompts can be delivered to players who are not the caller of
+// the action that triggered them (the mover/attacker's RPC response cannot
+// carry a prompt for a different player).
+//
+// The InputRequired payload is the same shape used in Interact / TakeAction
+// responses; clients can reuse the same prompt-modal infrastructure.
+message InputRequiredDelivered {
+  InputRequired input_required = 1;
 }
 
 // SnapshotDelivered is the first event on a new stream subscription. Carries the player's

--- a/dnd5e/api/v1alpha2/encounter/service.proto
+++ b/dnd5e/api/v1alpha2/encounter/service.proto
@@ -102,16 +102,53 @@ message EndTurnResponse {}
 // SubmitCheckRequest resolves the caller's currently-pending InputRequired prompt.
 // No correlation id: server tracks pending_prompt_per_player. If none is pending,
 // server returns FailedPrecondition.
+//
+// Wave 2.11d: take_reaction extends this RPC for reaction prompts. When the caller's
+// pending prompt is a ReactionPrompt, the server interprets take_reaction as the
+// reactor's choice (true = take the reaction, false = skip) and runs phase 2 of the
+// attack with or without the reaction modifier baked in. The roll field is ignored
+// in that case (reaction prompts don't carry a d20 roll).
 message SubmitCheckRequest {
   string encounter_id = 1;
   string entity_id = 2;
-  int32 roll = 3; // raw d20 result the client rolled
+  int32 roll = 3; // raw d20 result the client rolled (skill-check semantics)
+  // When set on a request that resolves a ReactionPrompt, indicates whether the
+  // reactor takes (true) or skips (false) the prompted reaction. Ignored for
+  // non-reaction prompt kinds.
+  optional bool take_reaction = 4;
   // Future: optional advantage/disadvantage, modifier breakdown
 }
 
 message SubmitCheckResponse {
   bool success = 1;
   int32 total = 2;
+}
+
+// SetReactionReadyRequest toggles whether a character has a specific reaction
+// readied. Readiness is opt-in per the Wave 2.11d design: condition handlers only
+// emit reaction triggers (and the server only pushes prompts) when the character
+// has the relevant reaction readied.
+//
+// Default readiness varies by reaction type and is set server-side at encounter
+// setup (free-cost reactions like OA are default-on for melee combatants;
+// spell-cost reactions like Shield are default-off; class-feature reactions
+// per-feature). Players use this RPC to override defaults.
+//
+// Spell-cost reactions auto-clear after firing (one-shot). Free reactions stay
+// ready until the player toggles them off.
+message SetReactionReadyRequest {
+  string encounter_id = 1;
+  string character_id = 2;
+  // Which reaction to toggle. Examples: dnd5e:conditions:opportunity_attack,
+  // dnd5e:spells:shield
+  Ref reaction_ref = 3;
+  // true = ready (will trigger prompts); false = unready (silent default)
+  bool ready = 4;
+}
+
+message SetReactionReadyResponse {
+  // Empty for now; success implied by no error.
+  // Future: return resulting readiness map for the character so clients can confirm state.
 }
 
 // =============================================================================
@@ -140,4 +177,10 @@ service EncounterService {
   // Resolves the caller's pending InputRequired prompt.
   // Returns FailedPrecondition if no prompt is pending.
   rpc SubmitCheck(SubmitCheckRequest) returns (SubmitCheckResponse);
+
+  // SetReactionReady toggles whether a character has a specific reaction readied.
+  // Wave 2.11d: opt-in readiness model. Conditions only publish ReactionTrigger
+  // events (which become InputRequired{reaction_prompt} stream events) when the
+  // reactor has the relevant reaction readied via this RPC.
+  rpc SetReactionReady(SetReactionReadyRequest) returns (SetReactionReadyResponse);
 }

--- a/dnd5e/api/v1alpha2/encounter/types.proto
+++ b/dnd5e/api/v1alpha2/encounter/types.proto
@@ -289,11 +289,18 @@ message MovementInterruption {
 // TakeActionResponse when the operation needs more input from the requester (skill check,
 // dialogue choice). Server tracks the pending prompt as encounter state; SubmitCheck
 // implicitly resolves it. No correlation id needed on the wire.
+//
+// Wave 2.11d: ReactionPrompt joins as a fourth variant. Unlike the other three, a
+// reaction prompt is NOT delivered as the response to the calling RPC — it rides
+// the per-viewer event stream as an EncounterEvent.InputRequired event because the
+// reactor isn't the caller. The reactor's stream receives the prompt; the reactor
+// responds via SubmitCheck with the take_reaction field set.
 message InputRequired {
   oneof kind {
     SkillCheckPrompt skill_check = 1;
     DialogueChoice dialogue = 2;
     TargetSelect target_select = 3;
+    ReactionPrompt reaction_prompt = 4;
   }
 }
 
@@ -314,4 +321,37 @@ message DialogueOption {
 
 message TargetSelect {
   repeated string candidate_entity_ids = 1;
+}
+
+// ReactionPrompt is the InputRequired variant pushed to a player who has a readied
+// reaction whose predicate matched at an attack/movement boundary. The player chooses
+// to take or skip the reaction by replying via SubmitCheck with the take_reaction field.
+//
+// The prompt rides the per-viewer event stream (EncounterEvent.InputRequired) projected
+// to the reactor only. The mover/attacker's RPC response returns normally with phase-1
+// results; the reactor's stream gets this prompt as an additional event.
+//
+// Per Wave 2.11d Decision Point 2 (rpg-project#47): reuse SubmitCheck for take/skip
+// in this wave; defer a richer SubmitReaction RPC to a future wave when reactions need
+// payloads beyond yes/no (Counterspell slot pick, Polearm Master target pick).
+message ReactionPrompt {
+  // The reaction the reactor is being asked to take.
+  // Examples: dnd5e:conditions:opportunity_attack, dnd5e:spells:shield
+  Ref reaction_ref = 1;
+
+  // What triggered the reaction prompt. Mirrors the toolkit's TriggerKind enum
+  // (rulebooks/dnd5e/events.TriggerKind): "movement_oa", "post_hit", "post_damage".
+  string trigger_kind = 2;
+
+  // The entity whose action triggered this reaction.
+  // For OA: the moving entity. For Shield: the attacker.
+  string trigger_source_entity_id = 3;
+
+  // The reaction's intended target.
+  // For OA: the moving entity (you OA the mover). For Shield: the reactor (you Shield yourself).
+  string target_entity_id = 4;
+
+  // Optional human-readable description for the reactor's UI.
+  // Server may pre-format ("Goblin attacks you. Cast Shield (+5 AC, 1st-level slot)?").
+  string display_text = 5;
 }


### PR DESCRIPTION
## Summary

Additive proto surface for Wave 2.11d player-reaction prompts:

- `InputRequired.reaction_prompt` oneof variant + `ReactionPrompt` message (reactor + condition ref + trigger kind + trigger source)
- `SubmitCheckRequest.take_reaction` optional bool: player accepts/skips a pending reaction prompt
- `SetReactionReady` RPC + req/resp messages: per-character readiness toggle for reaction conditions
- `EncounterEvent.InputRequiredDelivered` oneof variant + payload: per-viewer event delivering a reaction prompt to its reactor

All additive — no breaking changes to v1alpha2.

## Wave context

Part of the Wave 2.11d cross-repo unit. Tracker: KirkDiggler/rpg-project#47. Plan: [11-wave-2.11-condition-driven-reactions.md](https://github.com/KirkDiggler/rpg-project/blob/main/ideas/encounter/v1alpha2/plans/11-wave-2.11-condition-driven-reactions.md). The toolkit-side PR ships in parallel with this one (KirkDiggler/rpg-toolkit#TBD); rpg-api lands after both merge + autotag.

## Architectural reference

ADR-0027 (rpg-toolkit `docs/adr/0027-attack-resolution-and-reactions.md`) — discrete RPC phase model + reaction-trigger event shape. The prompt + RPC surface here is the wire-level half of the shipped ADR-0027 orchestration story.

## Test plan

- [x] `make pre-commit` clean (buf format, lint, breaking, generate, mocks)
- [x] Generated Go compiles (`make compile-go` direct path; the `compile-go` Make target reinit-fails on the worktree's pre-existing gen/go/go.mod, but `cd gen/go && go build ./...` passes clean)
- [x] Generated TS compiles (`make compile-ts`)
- [x] No breaking changes against main (`buf breaking --against '.git#branch=main'`)

Closes #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)