### PR TITLE
feat(v1alpha2): add DamageComponent message and damage_breakdown to EntityDamaged (#160)

### DIFF
--- a/dnd5e/api/v1alpha2/encounter/events.proto
+++ b/dnd5e/api/v1alpha2/encounter/events.proto
@@ -112,12 +112,30 @@ message EntityMoved {
   optional MovementInterruption interruption = 6;
 }
 
+// DamageComponent is a single source's contribution to a damage event.
+// source is an opaque identifier: toolkit SourceRef.String() for named
+// sources (e.g. "dnd5e:conditions:sneak_attack") or a category string
+// ("weapon", "ability") for generic ones. amount is the component's total
+// after all chain modifiers (dice + flat bonus). damage_type reuses the
+// Ref shape used by EntityDamaged.damage_type. is_critical marks components
+// doubled for a critical hit — useful for crit highlighting in the UI.
+message DamageComponent {
+  string source = 1;
+  int32 amount = 2;
+  Ref damage_type = 3;
+  bool is_critical = 4;
+}
+
 message EntityDamaged {
   string entity_id = 1;
   int32 amount = 2;
   Ref damage_type = 3; // {module:"dnd5e", type:"damage", id:"slashing"}
   HitPoints hp_after = 4;
   optional string source_entity_id = 5;
+  // Per-source breakdown. Empty when the resolver did not produce component
+  // data (e.g. stand-in resolver or NPC attacks). When non-empty, the sum
+  // of component amounts equals amount.
+  repeated DamageComponent damage_breakdown = 6;
 }
 
 message EntityHealed {


### PR DESCRIPTION
## Summary

- Adds `DamageComponent` message with fields: `source` (opaque string), `amount` (int32), `damage_type` (Ref), `is_critical` (bool)
- Adds `damage_breakdown` (field 6, repeated DamageComponent) to `EntityDamaged`
- Backward-compatible additive change — no existing fields touched, no breaking changes

## Context

Part of Chapter 2 Wave 1 cross-repo damage_breakdown wiring. The combat log in rpg-dnd5e-web needs to show "weapon damage + sneak attack" as separate lines when Alice attacks the goblin, proving Sneak Attack is firing.

The `source` field uses the toolkit's `SourceRef.String()` convention (e.g. `"dnd5e:conditions:sneak_attack"`) which the existing `DamageSourceBadge.formatLegacySource()` in the web already handles — no web component rewrites needed.

## Test plan

- [x] `buf lint` passes (no issues)
- [x] `buf format --diff --exit-code` passes (clean)
- [x] `buf breaking --against '.git#branch=main'` passes (no breaking changes)
- [x] `buf generate` produces correct Go + TS with `DamageComponent` struct and `GetDamageBreakdown()` accessor

Closes #160. Rolls up to rpg-api#550 (Chapter 2 Wave 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)