### PR TITLE
feat(v1alpha2): add armor_class to Entity message

### DIFF
--- a/dnd5e/api/v1alpha2/encounter/types.proto
+++ b/dnd5e/api/v1alpha2/encounter/types.proto
@@ -152,9 +152,10 @@ message Space {
 // =============================================================================
 
 // Entity is anything that can occupy a position in the space.
-// Common shape (id, position, type, display_name, optional hp, status_effects) is what
-// every entity carries because every entity is destructible-or-not and has-or-doesn't-have
-// visible statuses. The oneof carries the type-specific rich data.
+// Common shape (id, position, type, display_name, optional hp, armor_class,
+// status_effects) is what every entity carries because every entity is
+// destructible-or-not and has-or-doesn't-have visible statuses.
+// The oneof carries the type-specific rich data.
 message Entity {
   string id = 1; // runtime instance id; not a Ref
   Position position = 2;
@@ -162,6 +163,7 @@ message Entity {
   string display_name = 4;
   optional HitPoints hp = 5; // present only on destructibles
   repeated StatusEffect status_effects = 6; // visible only
+  optional int32 armor_class = 7; // present for characters and monsters; absent for props/obstacles
 
   oneof data {
     CharacterData character = 10;


### PR DESCRIPTION
## Summary

- Adds `optional int32 armor_class = 7` to the `Entity` message in `dnd5e/api/v1alpha2/encounter/types.proto`
- Top-level field sibling to `hp = 5` — covers characters AND monsters uniformly without touching `CharacterData` or `MonsterData`
- Field number 7, `optional`, so unset = absent (not 0); clients can distinguish "no AC reported" from "AC is 0"

Closes #162

## Test plan

- [ ] `buf lint` — passes (no lint errors)
- [ ] `buf format --diff --exit-code` — no diff (already formatted)
- [ ] `buf breaking --against '.git#branch=main'` — no breaking changes (additive field)
- [ ] `make test` — passes (lint + format + generate + mocks)
- [ ] CI auto-generates Go + TS SDKs on merge; `generated` branch updates automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)