### PR TITLE
feat(v1alpha2/encounter): add ResourceChanged event

### DIFF
--- a/dnd5e/api/v1alpha2/encounter/events.proto
+++ b/dnd5e/api/v1alpha2/encounter/events.proto
@@ -33,6 +33,7 @@ message EncounterEvent {
     EntityRemoved entity_removed = 24;
     StatusApplied status_applied = 25;
     StatusRemoved status_removed = 26;
+    ResourceChanged resource_changed = 61;
 
     // World interaction
     DoorOpened door_opened = 30;
@@ -164,6 +165,17 @@ message StatusApplied {
 message StatusRemoved {
   string entity_id = 1;
   Ref status_source = 2; // matches StatusEffect.source from earlier StatusApplied
+}
+
+// ResourceChanged reports a change in a tracked resource (e.g. rage charges,
+// ki points, spell slots) for an entity. The resource is identified by an opaque
+// ref so new resource types ride this event without a new proto field.
+// Example: {module:"dnd5e", type:"resources", id:"rage_charges"}, new_current=1, max=2.
+message ResourceChanged {
+  string entity_id = 1;
+  Ref resource_ref = 2; // e.g. {module:"dnd5e", type:"resources", id:"rage_charges"}
+  int32 new_current = 3;
+  int32 max = 4;
 }
 
 message DoorOpened {


### PR DESCRIPTION
## Summary

- Adds `ResourceChanged` message to `proto/dnd5e/api/v1alpha2/encounter/events.proto`
- Wires it into `EncounterEvent` oneof at tag 61 (next free tag after `InputRequiredDelivered = 60`)
- Carries `entity_id`, opaque `resource_ref` (e.g. `{module:"dnd5e", type:"resources", id:"rage_charges"}`), `new_current`, and `max`
- Purely additive: `buf breaking` confirms no compatibility breakage against main
- `make test` (lint + format + generate + mocks) green

## Design rationale

The `resource_ref` field is intentionally opaque (`Ref` type, same shape used by `EntityDamaged.damage_type`, `StatusRemoved.status_source`, etc.). This means rage charges, ki points, spell slots, and any future resource all ride this single envelope without requiring new proto fields — consistent with the event-envelope category vocabulary described in the Wave 0 design (Section 4).

Tag 61 was chosen as the next unused integer in the `EncounterEvent` oneof (tags 1–2 = metadata fields, 5–60 = oneof entries; 61 is the first gap after 60).

## Test plan

- [x] `buf lint` — clean (deprecation warning for `DEFAULT` category pre-dates this PR; not new)
- [x] `buf format --diff --exit-code` — no formatting delta
- [x] `buf breaking --against .git#branch=main` — no breaking changes
- [x] `buf generate` — Go and TS bindings generated successfully
- [x] Go: `ResourceChanged` struct + `GetResourceChanged()` accessor + `EncounterEvent_ResourceChanged` oneof wrapper present in `gen/go/dnd5e/api/v1alpha2/encounter/events.pb.go`
- [x] TS: `ResourceChanged` type + `ResourceChangedSchema` present in `gen/ts/dnd5e/api/v1alpha2/encounter/events_pb.ts`

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)