### PR TITLE
feat(v1alpha2/encounter): resolved-action event contract for TakeAction

### DIFF
--- a/dnd5e/api/v1alpha2/encounter/events.proto
+++ b/dnd5e/api/v1alpha2/encounter/events.proto
@@ -14,7 +14,17 @@ option java_package = "com.kirkdiggler.rpg.api.dnd5e.v1alpha2.encounter";
 // Same payload → same event with a wider type, not a new event.
 message EncounterEvent {
   int64 sequence = 1; // monotonic per encounter
+  // Game-event time, stamped by the toolkit at publish (its event `occurred_at`),
+  // NOT wire-delivery time. The toolkit owns when an event happened; rpg-api copies
+  // it through, never restamps with its own wall clock (Invariant 5).
   google.protobuf.Timestamp timestamp = 2;
+  // Causation key (Invariant 8). Ties every effect of one action together: an
+  // ActionResolved and the AttackResolved / EntityDamaged / StatusApplied events it
+  // caused all share the same correlation_id, so the toolkit-owned combat log can be
+  // reassembled from the stream. Opaque runtime id the toolkit stamps per action, so
+  // it's a string (not a Ref). Empty for events with no causing action (snapshot,
+  // geometry reveal, etc.).
+  string correlation_id = 3;
 
   oneof event {
     // Lifecycle
@@ -33,6 +43,12 @@ message EncounterEvent {
     EntityRemoved entity_removed = 24;
     StatusApplied status_applied = 25;
     StatusRemoved status_removed = 26;
+    // The resolved-action triple (TakeAction wave). ActionResolved is the umbrella
+    // beat (actor, action, economy consumed); AttackResolved carries the per-attack
+    // roll detail (incl. MISS — the #594 fix). Both share the envelope correlation_id
+    // with the EntityDamaged they cause, so the web reassembles the full story.
+    ActionResolved action_resolved = 27;
+    AttackResolved attack_resolved = 28;
     ResourceChanged resource_changed = 61;
 
     // World interaction
@@ -48,6 +64,7 @@ message EncounterEvent {
     TurnStarted turn_started = 42;
     TurnEnded turn_ended = 43;
     EncounterEnded encounter_ended = 44;
+    TurnStateChanged turn_state_changed = 45;
 
     // Dialogue
     DialogueStarted dialogue_started = 50;
@@ -178,6 +195,60 @@ message ResourceChanged {
   int32 max = 4;
 }
 
+// ActionResolved is the umbrella beat for a player-facing action (TakeAction wave).
+// Every action a character takes emits exactly one of these as a first-class record —
+// not just its scattered effects (Invariant 9). It carries WHAT was done and WHAT it
+// cost; the roll/hit/miss detail of an attack lives on the correlated AttackResolved,
+// and any damage on the correlated EntityDamaged. The web reassembles the full story
+// from the shared envelope correlation_id.
+//
+// This is a uniform broadcast record — every viewer sees the same ActionResolved. The
+// actor's refreshed menu is NOT carried here; it rides the separate TurnStateChanged
+// event (projected for audience), keeping this a clean combat-log entry.
+message ActionResolved {
+  string actor_entity_id = 1; // who took the action
+  // The action the actor submitted, carried as the toolkit's native ref verbatim:
+  // {module:"dnd5e", type:"combat_abilities", id:"attack"} for an ability beat, or
+  // {module:"dnd5e", type:"actions", id:"strike"} for a granted-capacity action.
+  // The two `type` namespaces are the toolkit's two-level economy and are NOT flattened
+  // on the wire — rpg-api copies the triple through, never remaps it (Invariant 2).
+  Ref action_ref = 2;
+  string target_entity_id = 3; // "" for self/untargeted actions (Dodge, Dash)
+  EconomyConsumed economy_consumed = 4; // the real deduction the toolkit made
+}
+
+// EconomyConsumed is the action-economy delta one ActionResolved spent. Mirrors the
+// toolkit's two-level model: the primary slots plus the granted-capacity map (e.g.
+// {"attacks":1} when a strike consumes one granted attack, {"martial_arts_bonus":1}
+// for the Monk bonus strike). The web subtracts these from the economy it holds; the
+// authoritative refreshed snapshot still arrives on TurnStateChanged.
+message EconomyConsumed {
+  int32 actions = 1;
+  int32 bonus_actions = 2;
+  int32 reactions = 3;
+  int32 movement = 4; // in feet (toolkit-native unit), matches ActionEconomy.movement_remaining
+  map<string, int32> granted_consumed = 5; // toolkit capacity keys: "attacks", "martial_arts_bonus", ...
+}
+
+// AttackResolved carries the per-attack roll detail. Correlated to its umbrella
+// ActionResolved (and to the EntityDamaged it causes on a hit) via the shared envelope
+// correlation_id. The attack story is the correlated triple:
+// ActionResolved (umbrella + economy) → AttackResolved (roll, hit/miss/crit) →
+// EntityDamaged (HP, hit only).
+//
+// CRUCIAL: this fires on a MISS too (hit=false). That is the #594 fix — today a miss
+// emits nothing and the story silently drops. No damage is carried here; damage lives
+// on the separate EntityDamaged event published alongside on a hit.
+message AttackResolved {
+  string attacker_entity_id = 1;
+  string target_entity_id = 2;
+  bool hit = 3;
+  bool critical = 4;
+  int32 attack_roll = 5; // raw d20 result
+  int32 attack_bonus = 6; // to-hit modifier applied
+  int32 target_ac = 7; // the AC the roll was compared against
+}
+
 message DoorOpened {
   string door_entity_id = 1;
   repeated Hex revealed_hexes = 2; // full hex (terrain + zone) for newly-visible cells
@@ -225,6 +296,22 @@ message TurnStarted {
 
 message TurnEnded {
   string entity_id = 1;
+}
+
+// TurnStateChanged pushes the active actor's refreshed turn state after an action
+// mutates it — the economy decremented and the recomputed available-actions menu
+// (TakeAction wave, Invariant 12: the menu never goes silently stale; refresh is
+// pushed as a delta, the web never polls).
+//
+// Carried separately from ActionResolved on purpose: available_actions is the active
+// actor's menu, so this event is projected for audience (it goes to whoever needs the
+// menu), whereas ActionResolved is a uniform broadcast record. Correlated to the
+// triggering ActionResolved via the shared envelope correlation_id.
+//
+// The web swaps in this TurnState wholesale — toolkit computes it, rpg-api projects it
+// field-for-field, the web renders it. No availability is recomputed client-side.
+message TurnStateChanged {
+  TurnState turn_state = 1; // recomputed economy + available_actions
 }
 
 message EncounterEnded {

--- a/dnd5e/api/v1alpha2/encounter/service.proto
+++ b/dnd5e/api/v1alpha2/encounter/service.proto
@@ -66,7 +66,10 @@ message InteractResponse {
 message TakeActionRequest {
   string encounter_id = 1;
   string actor_entity_id = 2;
-  Ref action_ref = 3; // {module:"dnd5e", type:"action", id:"attack"}
+  // The toolkit's native action ref, two namespaces, not flattened:
+  // {module:"dnd5e", type:"combat_abilities", id:"attack"} (the intent verb) or
+  // {module:"dnd5e", type:"actions", id:"strike"} (a granted-capacity action).
+  Ref action_ref = 3;
   ActionTarget target = 4;
   // Future: spell level, ki spend, etc.
 }

--- a/dnd5e/api/v1alpha2/encounter/types.proto
+++ b/dnd5e/api/v1alpha2/encounter/types.proto
@@ -93,6 +93,44 @@ enum TrapState {
   TRAP_STATE_DISARMED = 3;
 }
 
+// EconomySlot is which action-economy slot an AvailableAction draws from, so the web can
+// GROUP the menu by slot (TakeAction wave). Toolkit-authored — rpg-api copies it through,
+// the web never derives it from rules. Maps from the toolkit's action type; a granted-
+// capacity action (e.g. an off-hand strike) carries the slot of the capacity it spends.
+enum EconomySlot {
+  ECONOMY_SLOT_UNSPECIFIED = 0;
+  ECONOMY_SLOT_ACTION = 1;
+  ECONOMY_SLOT_BONUS_ACTION = 2;
+  ECONOMY_SLOT_REACTION = 3;
+  ECONOMY_SLOT_MOVEMENT = 4;
+  ECONOMY_SLOT_FREE = 5;
+}
+
+// TargetKind tells the UI which targeting prompt to raise for an AvailableAction without
+// the web knowing any rules (TakeAction wave). Toolkit-authored. Attack/strike =
+// SINGLE_ENTITY, Dodge = SELF, move = POSITION, a fireball = AREA, Dash = NONE.
+//
+// SELF/SINGLE_ENTITY/POSITION/AREA correspond to the ActionTarget oneof arms (service.proto):
+// the web reads target_kind on the menu entry, raises the matching prompt, and fills the
+// matching ActionTarget.kind in the request.
+//
+// Two values have no ActionTarget arm and are deliberate:
+//   - UNSPECIFIED (0): the toolkit did not set a kind — treat as a defect (a bug to surface).
+//   - NONE (5): the action is deliberately untargeted — fire it with no prompt and an
+//     empty/self ActionTarget. Distinct from SELF: a SELF action (Dodge) targets the actor
+//     (a self-buff lands on them), whereas a NONE action (Dash) targets nothing at all.
+//     Collapsing them would lose that the web should confirm-self for Dodge but prompt-
+//     nothing for Dash. The toolkit owns this distinction; the proto mirrors its enum 1:1
+//     so rpg-api projects target_kind field-for-field with no translation conditional.
+enum TargetKind {
+  TARGET_KIND_UNSPECIFIED = 0;
+  TARGET_KIND_SELF = 1;
+  TARGET_KIND_SINGLE_ENTITY = 2;
+  TARGET_KIND_POSITION = 3;
+  TARGET_KIND_AREA = 4;
+  TARGET_KIND_NONE = 5;
+}
+
 // =============================================================================
 // Space — flat hex map with optional zones
 // =============================================================================
@@ -259,11 +297,17 @@ message ActionEconomy {
 // AvailableAction is one entry in the server-pushed list of actions the active entity can
 // take right now. Web does not compute availability — it renders the list and disables
 // buttons whose `available` is false (showing `unavailable_reason` as tooltip).
+//
+// ref carries the toolkit's native ref verbatim (e.g. {type:"combat_abilities", id:"attack"}
+// or {type:"actions", id:"strike"}); the two `type` namespaces are the toolkit's two-level
+// economy and are not flattened on the wire.
 message AvailableAction {
-  Ref ref = 1; // {module:"dnd5e", type:"action", id:"attack"}
+  Ref ref = 1; // {module:"dnd5e", type:"combat_abilities", id:"attack"}
   string display_name = 2;
   bool available = 3;
   string unavailable_reason = 4; // user-facing: "no movement", "out of range", ...
+  EconomySlot economy_slot = 5; // which slot it draws from — web groups the menu by this
+  TargetKind target_kind = 6; // which targeting prompt the UI should raise
 }
 
 // MovementInterruption is attached to an EntityMoved event when the path was cut short.

--- a/docs/architecture/components/encounter-service.md
+++ b/docs/architecture/components/encounter-service.md
@@ -1,8 +1,8 @@
 ---
 name: EncounterService
-description: D&D 5e encounter contract — lobby, dungeon exploration, combat, action economy, event streaming
-updated: 2026-05-02
-confidence: high — verified by reading dnd5e/api/v1alpha1/encounter.proto end-to-end and grepping consumers
+description: D&D 5e encounter contract — lobby, dungeon exploration, combat, action economy, event streaming (v1alpha1) + the v1alpha2 TakeAction action-resolution contract
+updated: 2026-06-01
+confidence: high — v1alpha1 verified by reading dnd5e/api/v1alpha1/encounter.proto end-to-end; v1alpha2 TakeAction section verified against the edited dnd5e/api/v1alpha2/encounter/{events,types}.proto. Full v1alpha2 doc still owed (tracked).
 ---
 
 # EncounterService
@@ -261,3 +261,91 @@ unnecessarily. See [data-model.md pagination](../data-model.md#pagination-patter
   by rpg-api today; that's an rpg-api-member concern. If an event is
   defined but never emitted, that's drift in the proto-but-not-in-use
   direction.
+
+---
+
+# v1alpha2 EncounterService (the replacement)
+
+`dnd5e/api/v1alpha2/encounter/` is the clean-break replacement (design:
+`rpg-project/ideas/encounter/v1alpha2/design.md`). It is a different,
+room-free contract — hex-absolute geometry, tiered visibility, a typed
+semantic-verb event stream — split across three files:
+`types.proto`, `events.proto`, `service.proto`. This doc still documents
+the v1alpha1 surface above in full; the section below covers only the
+**TakeAction action-resolution contract** added for Chapter 2's
+TakeAction wave. A full v1alpha2 component doc is owed once the package
+stops moving (tracked drift — the rest of v1alpha2 is not yet documented
+here).
+
+## TakeAction event contract (Chapter 2, wave umbrella rpg-project #54)
+
+A character's action streams as a **correlated family** of events tied
+together by `EncounterEvent.correlation_id` (`events.proto`, envelope
+field 3). The toolkit stamps the id per action; rpg-api copies it
+through. The combat log is reassembled from this — see Invariant 8 in
+the design's North-Star Invariants.
+
+| Event | Tag | Carries | Notes |
+|---|---|---|---|
+| `ActionResolved` | 27 | actor, `action_ref`, target, `EconomyConsumed` | Umbrella beat — one per action (Invariant 9). Uniform broadcast record. |
+| `AttackResolved` | 28 | attacker, target, hit, critical, attack_roll, attack_bonus, target_ac | Per-attack roll detail. **Fires on a MISS too** (`hit=false`) — the #594 fix; un-suppressing without this proto variant is what threw `ErrUnknownEventType`. No damage here. |
+| `EntityDamaged` | 21 | amount, damage_type, hp_after, breakdown | Pre-existing. Published alongside `AttackResolved` on a hit, same correlation id. |
+| `TurnStateChanged` | 45 | full recomputed `TurnState` | Pushed after an action mutates the active actor's economy/menu (Invariant 12 — the menu never goes silently stale; no polling). |
+
+The attack story is the correlated triple
+`ActionResolved → AttackResolved → EntityDamaged` (the last only on a hit).
+
+**Why `TurnStateChanged` is separate from `ActionResolved`.**
+`TurnState.available_actions` is the *active actor's* menu — it is
+projected for audience (Invariant 6), so it can't ride the uniform
+broadcast `ActionResolved`. Keeping them separate preserves
+`ActionResolved` as a clean combat-log entry and lets the menu refresh
+be projected to whoever needs it.
+
+## Action menu fields
+
+`AvailableAction` (`types.proto`) gained two toolkit-authored fields so
+the web renders the menu without computing any rules:
+
+- `economy_slot` (`EconomySlot` enum) — which slot the action draws
+  from, so the web groups the menu by slot.
+- `target_kind` (`TargetKind` enum) — which targeting prompt the UI
+  raises. `SELF`/`SINGLE_ENTITY`/`POSITION`/`AREA` correspond to the
+  `ActionTarget` oneof arms (`service.proto`): the web reads `target_kind`,
+  raises the matching prompt, and fills the matching `ActionTarget.kind`
+  in the request. Two values have no arm: `UNSPECIFIED` (toolkit didn't
+  set it; treat as a defect) and `NONE` (deliberately untargeted — Dash;
+  fire with no prompt and an empty/self target). `NONE` ≠ `SELF`: a SELF
+  action (Dodge) targets the actor; a NONE action targets nothing. The
+  proto mirrors the toolkit's enum 1:1 so rpg-api projects it
+  field-for-field with no translation conditional.
+
+## Ref namespacing — two `type` namespaces, not flattened
+
+`action_ref` carries the toolkit's **native ref verbatim**, both
+namespaces of the two-level economy:
+
+- `{type:"combat_abilities", id:"attack"}` — the intent verb (spends
+  economy, grants capacity).
+- `{type:"actions", id:"strike"}` — the granted-capacity action.
+
+These are **not** flattened to a single `action:*` namespace on the
+wire. Flattening would be a rules-level remap that someone must own, and
+rpg-api is forbidden from rules conditionals (Invariant 2). `Ref` is
+already a `{module,type,id}` triple; carrying the namespace in `type`
+costs nothing and keeps rpg-api a pure passthrough. The web switches on
+the triple; it never needs the namespace to *mean* anything.
+
+## Causation timestamp
+
+`EncounterEvent.timestamp` is now sourced from the toolkit event's
+game-time `occurred_at` at publish, **not** rpg-api's wall clock at
+translate (Invariant 5). The proto field is unchanged; the sourcing is
+an rpg-api projection change.
+
+## Dependency order (D9)
+
+The proto variants here land **before** rpg-api stops suppressing the
+resolved-action event — otherwise the un-suppress yields
+`ErrUnknownEventType`. Critical path: protos #170 + toolkit #697/#698 →
+rpg-api #597 → web #426.


### PR DESCRIPTION
## What

Beat-1 of the **TakeAction** wave (Chapter 2). Adds the v1alpha2 `EncounterService` wire contract for faithful action resolution. Lands **first** in the pipeline so rpg-api can stop suppressing the resolved-action event against a real proto variant instead of throwing `ErrUnknownEventType` (decision D9).

Contract converged peer-to-peer with the toolkit expert against the **shipped toolkit structs** (`events.ActionResolvedEvent` / `AttackResolvedEvent` / `EconomyConsumed`, toolkit #698), and director-signed-off (D13). I own the wire encoding + buf discipline; the toolkit owns the semantics.

## Changes (all additive — `buf breaking` clean)

### `events.proto`
- **`correlation_id`** (string) on the `EncounterEvent` envelope — ties an action's whole family (`ActionResolved → AttackResolved → EntityDamaged → TurnStateChanged`) together (Invariant 8). `timestamp` doc re-pointed to the toolkit's game-time `occurred_at` (Invariant 5; api-side sourcing change, field unchanged).
- **`ActionResolved`** (tag 27) — the umbrella beat **every** action emits: actor, `Ref action_ref`, single `target_entity_id`, `EconomyConsumed`. No roll/outcome (Dodge/Dash/attack all emit it identically).
- **`EconomyConsumed`** — the two-level economy delta one action spent (`actions/bonus_actions/reactions/movement` + `granted_consumed` capacity map).
- **`AttackResolved`** (tag 28) — per-attack roll detail (`hit/critical/attack_roll/attack_bonus/target_ac`). **Fires on a MISS too** (`hit=false`) — the #594 fix; its absence was the `ErrUnknownEventType` blocker.
- **`TurnStateChanged`** (tag 45) — pushes the recomputed `TurnState` (economy + menu) after an action (Invariant 12, no polling). Kept **separate** from `ActionResolved` on the audience seam: `available_actions` is the actor's menu → projected per-viewer (Invariant 6), can't ride the uniform broadcast record.

### `types.proto`
- **`EconomySlot`** enum (`UNSPECIFIED/ACTION/BONUS_ACTION/REACTION/MOVEMENT/FREE`) — web groups the menu by slot.
- **`TargetKind`** enum (`UNSPECIFIED/SELF/SINGLE_ENTITY/POSITION/AREA`) — web raises the right targeting prompt. Mirrors the `ActionTarget` oneof arms 1:1.
- `AvailableAction` gains `economy_slot` (5) + `target_kind` (6), both toolkit-authored.

### `service.proto`
- `TakeActionRequest.action_ref` comment fixed to the **two-namespace** reality (`combat_abilities:*` intent verb + `actions:*` granted-capacity action), carried verbatim. Flattening to one namespace would be a rules remap (Invariant 2). Field unchanged (already a `Ref`).

### `docs/`
- Added a v1alpha2 TakeAction-contract section to `encounter-service.md` (was v1alpha1-only). Full v1alpha2 component doc flagged as still-owed tracked drift.

## Verification

- `buf lint` — 0 findings
- `buf breaking --against main` — clean (additive; no field renumber/removal)
- `make test` (lint + format check + generate Go+TS + mocks) — green; SDKs regenerated in sync
- Self `/code-review` (rpg-api-protos is not Copilot-reviewed) — 0 findings
- Existing rpg-api + web v1alpha2 consumers compile unchanged (purely additive)

Closes #170
Part of #54