### PR TITLE
docs(v1alpha2/encounter): fix Ref.type namespace examples (combat_abilities/actions)

### DIFF
--- a/dnd5e/api/v1alpha2/encounter/types.proto
+++ b/dnd5e/api/v1alpha2/encounter/types.proto
@@ -12,12 +12,15 @@ option java_package = "com.kirkdiggler.rpg.api.dnd5e.v1alpha2.encounter";
 
 // Ref is a typed reference to a piece of toolkit content.
 // module/type/id triple disambiguates across rulebooks and prevents id collisions.
-// Used everywhere the wire identifies a typed thing (action, monster, feature, condition,
-// damage type, item, ...). NOT used for runtime instance ids (encounter_id, entity_id) —
-// those stay strings. The `type` field is open-ended; toolkit grows the vocabulary.
+// Used everywhere the wire identifies a typed thing (combat_abilities, actions, monster,
+// feature, condition, damage type, item, ...). NOT used for runtime instance ids
+// (encounter_id, entity_id) — those stay strings. The `type` field is open-ended; the
+// toolkit grows the vocabulary and the wire carries its native namespaces verbatim (e.g.
+// the two-level economy's combat_abilities:* intent and actions:* doing are both `type`
+// values — never flattened on the wire).
 message Ref {
   string module = 1; // "dnd5e", future: "artificer", "homebrew-x"
-  string type = 2; // "monster", "feature", "condition", "action", "spell", "item", "damage", ...
+  string type = 2; // "monster", "feature", "condition", "combat_abilities", "actions", "spell", "item", "damage", ...
   string id = 3; // "goblin", "rage", "dodging", "attack"
 }
 


### PR DESCRIPTION
## What

Comment-only fix to the canonical `Ref` message in `dnd5e/api/v1alpha2/encounter/types.proto`. The `type` field examples still listed the old single `"action"` namespace, which became self-contradictory after #171 landed the two-namespace reality (the same file's `AvailableAction.ref` comment now references `combat_abilities`).

Updates the examples to the toolkit's two native economy namespaces — `combat_abilities:*` (intent verb) and `actions:*` (granted-capacity action) — and notes they're carried verbatim, never flattened on the wire (flattening would be a rules remap rpg-api is forbidden from doing, Invariant 2).

## Why

One-source-of-truth-for-shape: the canonical Ref doc shouldn't contradict the rest of the file mid-wave. Surfaced by the independent review gate on #171 as a non-blocking nit.

## Scope

- **Comment-only, zero wire impact.** No field, tag, message, or enum change.
- `buf lint` / `buf breaking` / `make test` all clean; generated code unaffected (a comment change doesn't alter generated Go/TS).

Part of #54