### PR TITLE
feat(v1alpha2/encounter): advantage/disadvantage fields on AttackResolved

### DIFF
--- a/dnd5e/api/v1alpha2/encounter/events.proto
+++ b/dnd5e/api/v1alpha2/encounter/events.proto
@@ -247,6 +247,14 @@ message AttackResolved {
   int32 attack_roll = 5; // raw d20 result
   int32 attack_bonus = 6; // to-hit modifier applied
   int32 target_ac = 7; // the AC the roll was compared against
+  // Copied verbatim from the toolkit's AttackResolvedEvent (rulebook's AttackResult) —
+  // consumers must never recompute advantage/disadvantage from other fields.
+  bool has_advantage = 8;
+  bool has_disadvantage = 9;
+  // The granting/imposing condition(s) (e.g. {module:"dnd5e", type:"conditions",
+  // id:"dodging"}), for narration. Empty when has_advantage/has_disadvantage is false.
+  repeated Ref advantage_sources = 10;
+  repeated Ref disadvantage_sources = 11;
 }
 
 message DoorOpened {


### PR DESCRIPTION
## Summary
Adds `has_advantage` / `has_disadvantage` bool fields plus `repeated Ref advantage_sources` / `disadvantage_sources` to the v1alpha2 `AttackResolved` event message, mirroring rpg-toolkit's `encounter.AttackResolvedEvent` fields added in KirkDiggler/rpg-toolkit#728 (`HasAdvantage`, `HasDisadvantage`, `AdvantageSources []*core.Ref`, `DisadvantageSources []*core.Ref`).

Closes #173
Refs KirkDiggler/rpg-project#75 (Beat 2: mechanical effects — Dodge/Help/Hide)

## Scope
- Additive only — nothing here needed alpha's breaking-change allowance.
- No new RPCs, no condition-display metadata field (per the wave design's R5 resolution — display resolution stays web-side via `StatusEffect.Source`, a bare `Ref`).
- Fields numbered 8-11, after the existing `target_ac = 7`.
- Uses the existing `Ref` message (module/type/id triple, `dnd5e/api/v1alpha2/encounter/types.proto`) for the source fields, following the same convention as `ActionResolved.action_ref`, `EntityDamaged.damage_type`, `ResourceChanged.resource_ref`, and `LootRevealed.items` (`repeated Ref`) — not a new/ad-hoc string representation.

## Fields added
```proto
message AttackResolved {
  ...
  int32 target_ac = 7;
  bool has_advantage = 8;
  bool has_disadvantage = 9;
  repeated Ref advantage_sources = 10;
  repeated Ref disadvantage_sources = 11;
}
```

## Load-bearing changes
- **Wire contract addition**: `AttackResolved` gains 4 new fields (8-11). This is the wire shape rpg-api#613 and rpg-dnd5e-web#430 will consume — land this first (dependency order per the wave issue).
- **Never-recompute rule**: `has_advantage`/`has_disadvantage`/`*_sources` are copied verbatim from the toolkit's resolved `AttackResult`. Consumers (rpg-api, rpg-dnd5e-web) must never recompute or re-derive advantage/disadvantage state from other fields — the toolkit is the sole source of truth for this calculation (Boundary Rule: toolkit implements RULES, everyone else copies through).

## Test plan
- [x] `make test` (buf lint + format + generate + mocks) — green
- [x] `buf format -w` — no diff (already conformant)
- [x] Confirmed `gen/` is gitignored; only the `.proto` source is committed (generated code lands via the `generated` branch on merge, per this repo's CI workflow)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

https://claude.ai/code/session_01E2xgbzQbNgFvkhBkmB3xQE