### PR TITLE
feat(lobby): LobbyService v1alpha1 — party assembly surface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ mocks: ## Generate mocks for gRPC services
 	mockgen -source=gen/go/dnd5e/api/v1alpha1/encounter_grpc.pb.go -destination=gen/go/dnd5e/api/v1alpha1/mocks/encounter_service.go -package=mocks
 	mkdir -p gen/go/dnd5e/api/v1alpha2/encounter/mocks
 	mockgen -source=gen/go/dnd5e/api/v1alpha2/encounter/service_grpc.pb.go -destination=gen/go/dnd5e/api/v1alpha2/encounter/mocks/encounter_service.go -package=mocks
+	mkdir -p gen/go/dnd5e/api/lobby/v1alpha1/mocks
+	mockgen -source=gen/go/dnd5e/api/lobby/v1alpha1/service_grpc.pb.go -destination=gen/go/dnd5e/api/lobby/v1alpha1/mocks/lobby_service.go -package=mocks
 	# Core API services
 	mkdir -p gen/go/api/v1alpha1/mocks
 	mockgen -source=gen/go/api/v1alpha1/dice_grpc.pb.go -destination=gen/go/api/v1alpha1/mocks/dice_service.go -package=mocks

--- a/dnd5e/api/lobby/v1alpha1/events.proto
+++ b/dnd5e/api/lobby/v1alpha1/events.proto
@@ -1,0 +1,70 @@
+syntax = "proto3";
+
+package dnd5e.api.lobby.v1alpha1;
+
+import "dnd5e/api/lobby/v1alpha1/types.proto";
+
+option go_package = "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/lobby/v1alpha1;lobbypb";
+option java_multiple_files = true;
+option java_package = "com.kirkdiggler.rpg.api.dnd5e.lobby.v1alpha1";
+
+// LobbyEvent is the unit of state delivery on StreamLobby. Membership + presence
+// only — no combat-log envelope (sequence/timestamp/correlation_id) like
+// EncounterEvent, because the lobby has no causation chains to reassemble; the
+// stream is short-lived and ends the moment encounter_started fires.
+message LobbyEvent {
+  oneof event {
+    // snapshot is always the first event delivered on a new StreamLobby
+    // subscription — mirrors StreamEncounter's snapshot-then-deltas pattern so a
+    // reconnecting client never needs a separate "get current state" call.
+    LobbySnapshot snapshot = 1;
+    MemberJoined member_joined = 2;
+    MemberLeft member_left = 3;
+    MemberReady member_ready = 4;
+    MemberConnectionChanged member_connection_changed = 5;
+    HostChanged host_changed = 6;
+    // Terminal event. WAITING -> STARTED is a one-way transition: after this,
+    // clients drop the lobby stream and subscribe StreamEncounter(encounter_id)
+    // instead. No further LobbyEvent is delivered on this stream.
+    EncounterStarted encounter_started = 7;
+  }
+}
+
+message LobbySnapshot {
+  repeated LobbyMember members = 1;
+}
+
+message MemberJoined {
+  LobbyMember member = 1;
+}
+
+message MemberLeft {
+  string player_id = 1;
+}
+
+message MemberReady {
+  string player_id = 1;
+  bool ready = 2;
+}
+
+// MemberConnectionChanged reports presence, not membership. Fired when a
+// player's StreamLobby subscription opens (connected = true) or drops
+// (connected = false). The seat is retained either way; only LeaveLobby emits
+// member_left.
+message MemberConnectionChanged {
+  string player_id = 1;
+  bool connected = 2;
+}
+
+// HostChanged fires when the host leaves (LeaveLobbyRequest) and the role
+// migrates to the oldest remaining member, rather than dissolving the lobby.
+message HostChanged {
+  string player_id = 1;
+}
+
+// EncounterStarted announces the toolkit encounter is already persisted
+// (persist-then-emit ordering is load-bearing: a client reacting to this event
+// must find the encounter already readable via StreamEncounter).
+message EncounterStarted {
+  string encounter_id = 1;
+}

--- a/dnd5e/api/lobby/v1alpha1/service.proto
+++ b/dnd5e/api/lobby/v1alpha1/service.proto
@@ -1,0 +1,148 @@
+syntax = "proto3";
+
+package dnd5e.api.lobby.v1alpha1;
+
+import "dnd5e/api/lobby/v1alpha1/events.proto";
+import "dnd5e/api/lobby/v1alpha1/types.proto";
+
+option go_package = "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/lobby/v1alpha1;lobbypb";
+option java_multiple_files = true;
+option java_package = "com.kirkdiggler.rpg.api.dnd5e.lobby.v1alpha1";
+
+// =============================================================================
+// RPC request / response messages
+// =============================================================================
+
+// CreateLobbyRequest starts a new lobby in the WAITING state. The caller becomes
+// host and is bound to character_id as the first member — the same
+// belongs-to-the-authenticated-player validation JoinLobbyRequest documents
+// applies here too.
+message CreateLobbyRequest {
+  string campaign_id = 1;
+  string character_id = 2;
+}
+
+// CreateLobbyResponse returns the opaque join_ref new members present to
+// JoinLobby. One join mechanism, two carriers: the Discord Activity supplies
+// join_ref automatically (everyone in the Activity shares an instance, nobody
+// types a code); dev/playtest passes the same ref via URL param or displayed
+// short code. The mapping from Discord instance to join_ref is rpg-api
+// internal — invisible to this contract, which only ever deals in join_ref.
+message CreateLobbyResponse {
+  string lobby_id = 1;
+  string join_ref = 2;
+  string host_player_id = 3;
+}
+
+// JoinLobbyRequest joins the lobby that minted join_ref at CreateLobby.
+//
+// Idempotent and rebinding: a player already in the lobby who calls again —
+// reconnect retry, second tab, or picking a different character — has
+// character_id rebound rather than erroring. This is also the only way to
+// change character pre-start; there is no separate re-select RPC. The server
+// validates character_id belongs to the authenticated caller.
+//
+// Returns FailedPrecondition if the lobby has already transitioned to STARTED
+// (WAITING -> STARTED is terminal; mid-encounter join is a future
+// encounter-side concern, not a lobby one) or if the party is already at the
+// server-enforced cap (4, config knob — not a contract field).
+message JoinLobbyRequest {
+  string join_ref = 1;
+  string character_id = 2;
+}
+
+message JoinLobbyResponse {
+  string lobby_id = 1;
+  repeated LobbyMember members = 2;
+}
+
+// SetReadyRequest toggles the caller's ready flag. Broadcast to the lobby as a
+// member_ready LobbyEvent; this response is a lean ack.
+message SetReadyRequest {
+  string lobby_id = 1;
+  bool ready = 2;
+}
+
+message SetReadyResponse {}
+
+// LeaveLobbyRequest removes the caller from the lobby. Pre-start only — once
+// WAITING -> STARTED has happened there is no lobby membership left to leave
+// (the encounter is the unit of membership from that point on). Explicit leave
+// is the only way a seat is freed; a dropped connection alone does not (see
+// MemberConnectionChanged in events.proto).
+//
+// If the caller is the host, the host role migrates to the oldest remaining
+// member (broadcast as HostChanged) rather than dissolving the lobby for
+// everyone else. A lobby whose last member leaves simply expires via a
+// refreshed-on-activity TTL — no reaper process, no contract field.
+message LeaveLobbyRequest {
+  string lobby_id = 1;
+}
+
+message LeaveLobbyResponse {}
+
+// StartEncounterRequest is the host's go/no-go moment: builds the toolkit
+// encounter from the current member set and hands the party off to it.
+//
+// Host-only — a non-host caller gets PermissionDenied. All-ready gated —
+// returns FailedPrecondition if any member's is_ready is false. Snapshots the
+// member set atomically against a racing LeaveLobby: a leave either lands
+// before the snapshot (member excluded) or after (FailedPrecondition, lobby
+// already STARTED). Marks the WAITING -> STARTED transition, which is
+// terminal; no lobby state survives the handoff.
+message StartEncounterRequest {
+  string lobby_id = 1;
+}
+
+// StartEncounterResponse returns the encounter_id clients switch to. Ordering
+// is load-bearing: the encounter is persisted before EncounterStarted is
+// emitted on the lobby stream, so a client reacting to that event is
+// guaranteed to find the encounter already there when it subscribes
+// StreamEncounter(encounter_id).
+message StartEncounterResponse {
+  string encounter_id = 1;
+}
+
+// StreamLobbyRequest subscribes to lobby membership events. player_id
+// identifies the subscriber for presence tracking (mirrors
+// StreamEncounterRequest's per-viewer field): subscribing flips this player's
+// is_connected true, the subscription dropping flips it false — broadcast
+// either way as MemberConnectionChanged. A dropped tab keeps its seat; only
+// LeaveLobby gives it up.
+message StreamLobbyRequest {
+  string lobby_id = 1;
+  string player_id = 2;
+}
+
+// =============================================================================
+// Service
+// =============================================================================
+
+service LobbyService {
+  // CreateLobby starts a new WAITING lobby; the caller becomes host.
+  rpc CreateLobby(CreateLobbyRequest) returns (CreateLobbyResponse);
+
+  // JoinLobby is idempotent and rebinds character_id for an existing member.
+  // FailedPrecondition if the lobby already STARTED or the party is at cap.
+  rpc JoinLobby(JoinLobbyRequest) returns (JoinLobbyResponse);
+
+  // SetReady toggles the caller's ready flag; broadcast as member_ready.
+  rpc SetReady(SetReadyRequest) returns (SetReadyResponse);
+
+  // LeaveLobby removes the caller, pre-start only. Host leaving migrates the
+  // host role (host_changed); the last member leaving lets the lobby expire
+  // via TTL rather than dissolving explicitly.
+  rpc LeaveLobby(LeaveLobbyRequest) returns (LeaveLobbyResponse);
+
+  // StartEncounter is host-only and all-ready gated. Builds the toolkit
+  // encounter, persists it, then emits encounter_started. WAITING -> STARTED
+  // is terminal — this is the only way a lobby becomes an encounter, replacing
+  // EncounterService.CreateEncounter's single-caller construction path.
+  rpc StartEncounter(StartEncounterRequest) returns (StartEncounterResponse);
+
+  // StreamLobby is the primary state delivery channel — mirrors StreamEncounter's
+  // snapshot-then-deltas: the first event on subscribe is always a LobbySnapshot.
+  // Ends when EncounterStarted fires; clients then subscribe
+  // StreamEncounter(encounter_id) instead.
+  rpc StreamLobby(StreamLobbyRequest) returns (stream LobbyEvent);
+}

--- a/dnd5e/api/lobby/v1alpha1/service.proto
+++ b/dnd5e/api/lobby/v1alpha1/service.proto
@@ -103,15 +103,15 @@ message StartEncounterResponse {
   string encounter_id = 1;
 }
 
-// StreamLobbyRequest subscribes to lobby membership events. player_id
-// identifies the subscriber for presence tracking (mirrors
-// StreamEncounterRequest's per-viewer field): subscribing flips this player's
+// StreamLobbyRequest subscribes to lobby membership events. The subscriber's
+// identity for presence tracking comes from the authenticated context, not a
+// request field (a client-supplied player_id would let a caller flip another
+// member's presence) — subscribing flips the authenticated caller's
 // is_connected true, the subscription dropping flips it false — broadcast
 // either way as MemberConnectionChanged. A dropped tab keeps its seat; only
 // LeaveLobby gives it up.
 message StreamLobbyRequest {
   string lobby_id = 1;
-  string player_id = 2;
 }
 
 // =============================================================================

--- a/dnd5e/api/lobby/v1alpha1/types.proto
+++ b/dnd5e/api/lobby/v1alpha1/types.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+package dnd5e.api.lobby.v1alpha1;
+
+option go_package = "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/lobby/v1alpha1;lobbypb";
+option java_multiple_files = true;
+option java_package = "com.kirkdiggler.rpg.api.dnd5e.lobby.v1alpha1";
+
+// LobbyMember is one player's seat in the lobby's party-assembly roster.
+//
+// character_name is server-enriched (looked up from the character store at
+// join/create time) — the web renders it, never fetches-and-computes. Later
+// party display fields (class, level) enrich the same way.
+//
+// is_connected is presence, not membership: a dropped StreamLobby subscription
+// flips is_connected false but keeps the seat. Only explicit LeaveLobby removes
+// a member (see LeaveLobbyRequest in service.proto).
+message LobbyMember {
+  string player_id = 1;
+  string character_id = 2;
+  string character_name = 3;
+  bool is_host = 4;
+  bool is_ready = 5;
+  bool is_connected = 6;
+}

--- a/dnd5e/api/v1alpha2/encounter/service.proto
+++ b/dnd5e/api/v1alpha2/encounter/service.proto
@@ -13,16 +13,6 @@ option java_package = "com.kirkdiggler.rpg.api.dnd5e.v1alpha2.encounter";
 // RPC request / response messages
 // =============================================================================
 
-message CreateEncounterRequest {
-  string campaign_id = 1;
-  EncounterMode initial_mode = 2;
-  // Future: party composition, dungeon ref, scenario ref
-}
-
-message CreateEncounterResponse {
-  Encounter encounter = 1;
-}
-
 message GetEncounterRequest {
   string encounter_id = 1;
 }
@@ -171,7 +161,11 @@ message ActivateFeatureResponse {
 
 service EncounterService {
   // Lifecycle
-  rpc CreateEncounter(CreateEncounterRequest) returns (CreateEncounterResponse);
+  //
+  // Encounter construction moved to lobby.v1alpha1.LobbyService.StartEncounter
+  // (rpg-api-protos#176): a solo lobby is the one-player start path, so the old
+  // single-caller CreateEncounter and the lobby's N-member seeding no longer
+  // need to coexist as two divergent construction paths.
   rpc GetEncounter(GetEncounterRequest) returns (GetEncounterResponse);
 
   // Stream — primary state delivery channel.

--- a/docs/architecture/components/lobby-service.md
+++ b/docs/architecture/components/lobby-service.md
@@ -1,0 +1,100 @@
+---
+name: LobbyService
+description: D&D 5e party-assembly contract (v1alpha1) — join/ready/start, the slice-1 seam that feeds encounter construction
+updated: 2026-07-06
+confidence: high — proto-side only; no consumer yet, verified by reading the design doc and the committed .proto files
+---
+
+# LobbyService
+
+Defined in `dnd5e/api/lobby/v1alpha1/` (service-first layout: `service.proto`,
+`types.proto`, `events.proto` — mirrors `dnd5e/api/v1alpha2/encounter/`'s
+split). Package `dnd5e.api.lobby.v1alpha1`.
+
+Design doc: `rpg-project/ideas/game-screen-rebuild/lobby-surface.md`. Umbrella:
+`KirkDiggler/rpg-project#81`. This service closes the gap the design doc
+names: nothing on `v1alpha2` could assemble a multiplayer party before this —
+the only multi-player v2 encounters that ever existed were devseed fixtures
+written straight to Redis, bypassing the RPC surface entirely.
+
+## Why a separate service, not RPCs on `EncounterService`
+
+Services version independently. `EncounterService` is where iteration churn
+lives (TakeAction wave, reactions, death saves); the lobby can stay stable —
+or grow a feature — without forcing an encounter-service rewrite. It also
+keeps the encounter types a clean 1:1 toolkit mirror: a lobby is pure API
+orchestration state (join refs, membership, ready flags, lifecycle), and the
+toolkit has zero lobby concept. Bolting a `WAITING` pseudo-mode onto
+`EncounterMode` would have polluted an enum that maps straight onto toolkit
+state.
+
+The lobby starts at its own `v1alpha1` and versions on its own clock —
+deliberately not `v1alpha2` to match the encounter service's current version;
+lining a new service up with another service's version number would
+re-import the whole-API-versioning habit the service split exists to avoid
+(`rpg-project#80`).
+
+## RPCs
+
+| RPC | Request:Response | Notes |
+|---|---|---|
+| `CreateLobby` | `CreateLobbyRequest:CreateLobbyResponse` | Starts a `WAITING` lobby; caller becomes host and binds `character_id` |
+| `JoinLobby` | `JoinLobbyRequest:JoinLobbyResponse` | Idempotent — rebinds `character_id` for an existing member rather than erroring. `FailedPrecondition` if already `STARTED` or at party cap |
+| `SetReady` | `SetReadyRequest:SetReadyResponse` | Toggles caller's ready flag; broadcasts `member_ready` |
+| `LeaveLobby` | `LeaveLobbyRequest:LeaveLobbyResponse` | Pre-start only. Host leaving migrates host role (`host_changed`), doesn't dissolve the lobby |
+| `StartEncounter` | `StartEncounterRequest:StartEncounterResponse` | Host-only, all-ready gated. Builds the toolkit encounter, persists it, then emits `encounter_started`. Terminal — subsumes the deleted `EncounterService.CreateEncounter` |
+| `StreamLobby` | `StreamLobbyRequest:stream LobbyEvent` | Snapshot-then-deltas, mirrors `StreamEncounter`. Ends at `encounter_started`; clients switch to `StreamEncounter(encounter_id)` |
+
+## Messages
+
+- `LobbyMember` (`types.proto`) — `player_id`, `character_id`,
+  `character_name` (server-enriched, never client-computed), `is_host`,
+  `is_ready`, `is_connected`.
+- `LobbyEvent` (`events.proto`) — oneof: `snapshot` (first event on
+  subscribe), `member_joined`, `member_left`, `member_ready`,
+  `member_connection_changed`, `host_changed`, `encounter_started`
+  (terminal). No combat-log envelope (no `sequence`/`timestamp`/
+  `correlation_id` like `EncounterEvent`) — the lobby has no causation
+  chains to reassemble and the stream is short-lived.
+
+## Contract edge cases (decided at design time, not left to implementation)
+
+- **Presence vs. membership**: `is_connected` flips on `StreamLobby`
+  subscribe/disconnect, broadcast as `member_connection_changed`. A dropped
+  tab keeps its seat — only explicit `LeaveLobby` removes a member.
+- **Host migration**: host leaving reassigns to the oldest remaining member
+  rather than dissolving the lobby.
+- **Late join**: `JoinLobby` on a `STARTED` lobby → `FailedPrecondition`.
+  Mid-encounter join is a future encounter-side concern, not a lobby one.
+- **Join is idempotent**: repeat `JoinLobby` calls (reconnect, second tab,
+  character re-pick) rebind rather than error — the only re-select path.
+- **Start/leave atomicity**: `StartEncounter` snapshots members atomically;
+  a racing `LeaveLobby` lands either before (excluded) or after
+  (`FailedPrecondition`).
+- **Abandonment**: TTL-based expiry (refreshed on activity), no reaper
+  process, no contract field — same pattern as the v2 encounter repo.
+- **Party cap**: server-enforced (4 to start), `FailedPrecondition` over
+  cap — a config knob, not a contract field.
+
+## One join mechanism, two carriers
+
+`JoinLobby` takes an opaque `join_ref` minted at `CreateLobby`. The Discord
+Activity carrier supplies it automatically (shared channel instance); the
+dev/playtest carrier passes the same ref via URL param or displayed short
+code. The instance→`join_ref` mapping is rpg-api internal — invisible to
+this contract, which only ever deals in `join_ref`.
+
+## What was deleted alongside this
+
+`EncounterService.CreateEncounter` and its request/response messages
+(`dnd5e/api/v1alpha2/encounter/service.proto`) — see the Rule 2 worked
+example in [overview.md](../overview.md#rule-2-buf-breaking-is-authoritative-not-advisory).
+A solo lobby is the one-player start path; keeping both constructors would
+have been the two-parallel-shapes smell overview.md's Rule 1 names.
+
+## Status
+
+Proto-only as of this doc. No `rpg-api` handler/orchestrator/repository yet
+(tracked as the next leg of `rpg-project#81`) and no `rpg-dnd5e-web` client
+usage. Not yet a "live" service by this repo's usual definition — flag for
+re-grading once the rpg-api PR lands.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -34,6 +34,14 @@ rpg-api-protos/
     enums.proto                 # Race, Class, Skill, Spell, etc.
     choices.proto               # Choice, ChoiceSubmission, ChoiceData
     equipment_types.proto       # Equipment, WeaponData, ArmorData, GearData
+  dnd5e/api/v1alpha2/encounter/  # service-first layout; TakeAction-wave encounter contract
+    service.proto               # EncounterService — live; RPCs + request/response messages
+    types.proto                 # Ref, Position, Entity, Space, TurnState, ActionEconomy, ...
+    events.proto                # EncounterEvent stream — snapshot + deltas
+  dnd5e/api/lobby/v1alpha1/      # service-first layout; own version clock (rpg-project#80)
+    service.proto                # LobbyService — party-assembly RPCs; not yet consumed (rpg-api pending)
+    types.proto                  # LobbyMember
+    events.proto                 # LobbyEvent stream — snapshot + membership/presence deltas
   sandbox/api/v1alpha1/
     sandbox_common.proto        # GenerativeRoomConfig, RoomShape, etc. — defined, not consumed
     sandbox_room.proto          # SandboxRoomService — defined, not consumed
@@ -135,6 +143,15 @@ The override is intentional: alpha packages permit breaking changes, but
 each one requires explicit reviewer acknowledgment via the label, not a
 silent merge with a yellow x. Stable (v1+) services should bump the package
 version (`v1`→`v2`) instead of using the override.
+
+**Worked example: `EncounterService.CreateEncounter` removed (rpg-api-protos#176,
+2026-07-06).** The lobby service's `StartEncounter` subsumes it — a solo lobby
+is the one-player start path, so the old single-caller construction RPC and the
+lobby's N-member seeding no longer need to coexist as two divergent
+constructors. `CreateEncounterRequest`/`CreateEncounterResponse` were deleted
+outright (no `reserved`, since RPC removal isn't a message-field retirement);
+`buf breaking` flags it as expected, carried via the override label per the
+design in `rpg-project/ideas/game-screen-rebuild/lobby-surface.md`.
 
 ### Rule 3: Deprecated fields are retired in the same release as their replacement
 

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -156,6 +156,24 @@ extensible shape. `Cost` and `Weight` as separate messages with
 `quantity + unit` is overkill for D&D 5e (gp/sp/cp; lbs) but correct in
 spirit.
 
+## Newly defined, consumer PR pending
+
+### dnd5e.lobby.LobbyService — B+ (provisional)
+
+Landed 2026-07-06 (rpg-api-protos#176), no consumer yet — distinct from the
+"defined-but-not-consumed" bucket below because an `rpg-api` handler PR is
+the immediate next leg of the same umbrella issue (`rpg-project#81`), not
+speculative schema. Service-first layout (`service.proto`/`types.proto`/
+`events.proto`) matches the precedent `dnd5e/api/v1alpha2/encounter/` set.
+Six focused RPCs, one join mechanism (`join_ref`) with two carriers
+documented in comments rather than invented as separate contract paths.
+`LobbyEvent` deliberately skips `EncounterEvent`'s combat-log envelope
+(sequence/timestamp/correlation_id) since there's no causation chain to
+reassemble — right-sized rather than copy-pasted. Held below A by: no
+runtime validation this shape survives contact with the orchestrator layer
+yet, and `character_name` enrichment / party-cap config aren't verifiable
+from the proto alone. Re-grade once the rpg-api PR lands.
+
 ## Defined-but-not-consumed services
 
 These services compile, lint clean, and ship in the generated SDKs, but

--- a/docs/status.md
+++ b/docs/status.md
@@ -16,6 +16,16 @@ shape and consumer drift, it shows up here as a "rough edge."
 
 ## Active work
 
+- **LobbyService v1alpha1 (rpg-api-protos#176, 2026-07-06)** — new
+  `dnd5e/api/lobby/v1alpha1/` service: `CreateLobby`, `JoinLobby`, `SetReady`,
+  `LeaveLobby`, `StartEncounter`, `StreamLobby`. Party-assembly slice 1 of the
+  game-screen rebuild (`rpg-project#81`; design at
+  `rpg-project/ideas/game-screen-rebuild/lobby-surface.md`). Also removes
+  `EncounterService.CreateEncounter` (`dnd5e/api/v1alpha2/encounter/`) —
+  subsumed by `LobbyService.StartEncounter` — carried via the
+  `breaking-change-approved` label. Proto-only so far; no `rpg-api` handler
+  or `rpg-dnd5e-web` client yet (next legs of the same umbrella issue).
+
 - **PR #136 just merged (2026-04-03)** — unified entity state protos
   (`EntityState`, `CharacterDetails`, `MonsterDetails`, `ObstacleDetails`,
   `EncounterStateData`, `RoomLayout`). Currently no open PRs. Branch


### PR DESCRIPTION
## Summary

New `dnd5e.api.lobby.v1alpha1` `LobbyService` — the party-assembly surface nothing on v1alpha2 could do before (the only multiplayer v2 encounters that ever existed were devseed fixtures written straight to Redis, bypassing the RPC surface entirely).

Six RPCs: `CreateLobby`, `JoinLobby`, `SetReady`, `LeaveLobby`, `StartEncounter`, `StreamLobby`. Service-first layout (`service.proto`/`types.proto`/`events.proto`) mirroring `dnd5e/api/v1alpha2/encounter/`. Own v1alpha1 version clock, deliberately not v1alpha2, per rpg-project#80.

Also deletes `EncounterService.CreateEncounter` (+ its request/response messages) from `dnd5e/api/v1alpha2/encounter/service.proto` — subsumed by `StartEncounter` (a solo lobby is the one-player start path). This is an intentional breaking change; applying the `breaking-change-approved` label.

Closes #176
Umbrella: KirkDiggler/rpg-project#81
Design: `rpg-project/ideas/game-screen-rebuild/lobby-surface.md` (on rpg-project main)

## Load-bearing

- One join mechanism (`join_ref`), two carriers: Discord Activity instance auto-supplies it, dev/playtest passes it explicitly via URL param/short code — documented in comments, not built as two contract paths.
- `JoinLobby` is idempotent and rebinds `character_id` for an existing member (reconnect, second tab, re-pick) rather than erroring — the only re-select path, no separate RPC.
- `StartEncounter` is host-only, all-ready gated, and snapshots membership atomically against a racing `LeaveLobby`; `WAITING -> STARTED` is terminal and no lobby state survives the handoff.
- Presence (`is_connected`) is tracked separately from membership: a dropped `StreamLobby` subscription flips presence, not membership — only explicit `LeaveLobby` frees a seat, and host leaving migrates the host role instead of dissolving the lobby.
- `LobbyEvent` deliberately omits `EncounterEvent`'s combat-log envelope (sequence/timestamp/correlation_id) — no causation chain to reassemble, so it stays lean.

## Test plan

- [x] `buf lint` — clean
- [x] `buf format --diff --exit-code` — clean
- [x] `buf breaking --against '.git#branch=main'` — flags the intended `CreateEncounter` removal as expected; carried via `breaking-change-approved` label
- [x] `buf generate` — succeeds, Go + TS output present under `gen/` (gitignored, not committed)
- [x] `make mocks` — succeeds, including the new `gen/go/dnd5e/api/lobby/v1alpha1/mocks` target added to the Makefile
- [x] Docs updated in this PR: new `docs/architecture/components/lobby-service.md`, `overview.md` repo layout + Rule 2 worked example, `status.md` active-work entry, `quality.md` provisional grade

🤖 Generated with [Claude Code](https://claude.com/claude-code)