### PR TITLE
chore(v1alpha2): deprecate dead StreamEncounterRequest fields

### DIFF
--- a/dnd5e/api/v1alpha2/encounter/service.proto
+++ b/dnd5e/api/v1alpha2/encounter/service.proto
@@ -23,8 +23,14 @@ message GetEncounterResponse {
 
 message StreamEncounterRequest {
   string encounter_id = 1;
-  string player_id = 2;
-  optional int64 last_seen_sequence = 3; // for reconnect/replay
+  // player_id and last_seen_sequence were never read: viewer identity comes
+  // exclusively from the authenticated context (matching StreamLobbyRequest,
+  // which never carried a client-id field), and there is no incremental
+  // resume-by-sequence path today — every (re)connect gets a full resync.
+  // Real resume-by-sequence is a future feature, not a wiring gap; see
+  // rpg-api-protos#178.
+  reserved 2, 3;
+  reserved "player_id", "last_seen_sequence";
 }
 
 message MoveEntityRequest {
@@ -169,8 +175,11 @@ service EncounterService {
   rpc GetEncounter(GetEncounterRequest) returns (GetEncounterResponse);
 
   // Stream — primary state delivery channel.
-  // Server sends an initial snapshot as the first event, then deltas. Reconnects pass
-  // last_seen_sequence to resume; if gap is too large, server sends a fresh snapshot.
+  // Server sends an initial snapshot as the first event, then deltas. Every
+  // (re)connect gets a full snapshot resync — there is no incremental
+  // resume-by-sequence today (rpg-api-protos#178 removed the unimplemented
+  // last_seen_sequence field; a real resume-by-sequence design is future work,
+  // tracked separately).
   rpc StreamEncounter(StreamEncounterRequest) returns (stream EncounterEvent);
 
   // World actions — emit events on the stream. Caller-private follow-ups (skill check,

--- a/dnd5e/api/v1alpha2/encounter/service.proto
+++ b/dnd5e/api/v1alpha2/encounter/service.proto
@@ -23,14 +23,15 @@ message GetEncounterResponse {
 
 message StreamEncounterRequest {
   string encounter_id = 1;
-  // player_id and last_seen_sequence were never read: viewer identity comes
-  // exclusively from the authenticated context (matching StreamLobbyRequest,
-  // which never carried a client-id field), and there is no incremental
-  // resume-by-sequence path today — every (re)connect gets a full resync.
-  // Real resume-by-sequence is a future feature, not a wiring gap; see
+  // Deprecated: ignored; identity comes from auth context (matches
+  // StreamLobbyRequest, which never carried a client-id field). See
   // rpg-api-protos#178.
-  reserved 2, 3;
-  reserved "player_id", "last_seen_sequence";
+  string player_id = 2 [deprecated = true];
+  // Deprecated: never implemented; every (re)connect gets a full snapshot
+  // resync. Resume-by-sequence, if built, will be designed fresh (rather
+  // than wired onto this field) once rpg-toolkit#765 gives the initiative
+  // roster its own real sequence number. See rpg-api-protos#178.
+  optional int64 last_seen_sequence = 3 [deprecated = true];
 }
 
 message MoveEntityRequest {


### PR DESCRIPTION
## Summary

Deprecates `player_id` and `last_seen_sequence` on `StreamEncounterRequest` (dnd5e/api/v1alpha2/encounter/service.proto) — marks both `[deprecated = true]` with doc comments that say what actually happens, instead of removing them. Direction per Kirk: alpha packages *can* take breaking changes, but "because we can doesn't mean we have to" — accumulated cruft gets cleaned at a whole-package version bump, not field-by-field. This PR is therefore non-breaking; no `buf breaking` bypass needed.

Closes #178

## Rationale (no Copilot coverage on this repo — full case here)

Investigated as part of the reconnect-fidelity wave (rpg-api#649). Traced every call site in rpg-api's `internal/handlers/dnd5e/v2/encounter/handler.go` — neither field is ever read.

**`player_id`**: viewer identity for `StreamEncounter` comes exclusively from `auth.GetPlayerID(ctx)` — the authenticated context, never the request body. This is intentional and correct: honoring a client-supplied `player_id` instead would be a trust regression (a client could claim to be any player). The lobby stream already establishes the pattern this should match — `StreamLobbyRequest` doesn't declare a player-identity field at all (`{lobby_id}` only); `internal/handlers/dnd5e/lobby/v1alpha1/stream_lobby.go` reads identity from ctx exclusively.

**`last_seen_sequence`**: there is no incremental resume path today, on either stream. Every (re)connect gets a full resync: a fresh snapshot plus `BuildReplayEvents`-synthesized replay events, all of which are hardcoded to `Sequence: 0` (they're not real sequence numbers, just replay markers). So even if a client populated this field, nothing on the server reads it — there's no gap-fill logic to drive.

Real resume-by-sequence is a genuine future feature, not "finish wiring this field": today's live event sequences work (`nextSeq()` increments a real, persisted per-encounter counter — rpg-toolkit/encounter/encounter.go), but the wave-1 `InitiativeRolled` event currently *borrows* `ModeChanged`'s sequence number as an interim measure (rather than carrying its own), and rpg-toolkit#765 is expected to give the initiative roster a proper sequence of its own. Designing a resume-by-sequence contract against today's borrowed/zero sequence values would bake in the wrong semantics. If/when that feature is built, it gets its own field(s) designed fresh against the corrected sequence model, not a resurrection of this one.

## Change

```proto
message StreamEncounterRequest {
  string encounter_id = 1;
  // Deprecated: ignored; identity comes from auth context (matches
  // StreamLobbyRequest, which never carried a client-id field). See
  // rpg-api-protos#178.
  string player_id = 2 [deprecated = true];
  // Deprecated: never implemented; every (re)connect gets a full snapshot
  // resync. Resume-by-sequence, if built, will be designed fresh (rather
  // than wired onto this field) once rpg-toolkit#765 gives the initiative
  // roster its own real sequence number. See rpg-api-protos#178.
  optional int64 last_seen_sequence = 3 [deprecated = true];
}
```

Also corrected the `StreamEncounter` RPC's doc comment, which described the never-implemented last_seen_sequence resume behavior as if it were current — it now says what the server actually does (full resync every connect). That part is unchanged from the original version of this PR.

## Load-bearing

- This is a **deprecation, not a removal**. Both fields stay on the wire, both still exist in generated code on every consumer. Nothing currently reads them, so nothing changes behaviorally.
- Consumers keep compiling as-is. `rpg-dnd5e-web`'s `src/api/useEncounterStream.ts:114-118` still writes `create(StreamEncounterRequestSchema, { encounterId, playerId })` — that write was always dead (the server never read it) and stays dead. It is now flagged `[deprecated = true]` in the generated types, which most codegen surfaces as an IDE/lint hint, not a compile error. Cleaning it up in web is optional, whenever convenient — nothing forces it.
- Real resume-by-sequence remains future work, gated on rpg-toolkit#765 giving the roster event a real sequence number. This PR doesn't build toward that field; it just stops the current field from silently implying a capability that was never implemented.
- Follow-up (separate rpg-api PR, not this one): bump generated protos via `GOPROXY=direct go get github.com/KirkDiggler/rpg-api-protos/gen/go@generated` once this merges and the `generated` branch updates. No rpg-api handler code references either field today, so that PR is a pure dependency bump plus full suite verification — no logic changes, no handler cleanup needed (nothing to remove, since nothing read the fields to begin with).

## Test plan
- [x] `make test` (buf lint + buf format --diff --exit-code + buf generate + mocks) — clean, no errors
- [x] `buf breaking --against 'https://github.com/KirkDiggler/rpg-api-protos.git#branch=main'` — passes naturally (deprecation is non-breaking; no label/config needed)
- [x] Confirmed `gen/` is gitignored in this repo (generated code ships via the `generated` branch, not this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gA28TEYiq8UFMqbTZL3K9
