### PR TITLE
feat(lobby): add GetMyActiveLobby RPC for resume-after-refresh

### DIFF
--- a/dnd5e/api/lobby/v1alpha1/service.proto
+++ b/dnd5e/api/lobby/v1alpha1/service.proto
@@ -114,6 +114,39 @@ message StreamLobbyRequest {
   string lobby_id = 1;
 }
 
+// GetMyActiveLobbyRequest looks up the authenticated caller's own active
+// lobby — no request fields. Identity comes from the authenticated context,
+// matching StreamLobbyRequest's pattern: a client-supplied player_id would
+// let a caller query another player's lobby.
+//
+// Built for resume-after-refresh (rpg-dnd5e-web#444): a client that has lost
+// all in-memory session state (page reload, crash, cold Discord Activity
+// launch) calls this once to learn whether it should skip straight back into
+// a lobby or a running encounter instead of landing on Home.
+message GetMyActiveLobbyRequest {}
+
+// GetMyActiveLobbyResponse reports the caller's active lobby, if any.
+//
+// An empty lobby_id means "no active lobby" — this is the normal response,
+// not an error. Every player who is not currently in a lobby or encounter
+// gets this on every app-mount call, so error-as-control-flow would be the
+// wrong shape here.
+//
+// encounter_id is set if and only if lobby_status is STARTED AND the server
+// has verified the encounter is still live (exists and has not ended). A
+// STARTED lobby record is a one-way, terminal transition on the lobby side
+// (see LeaveLobbyRequest) — nothing marks it when the encounter it points to
+// later ends — so lobby_status alone cannot distinguish "still fighting"
+// from "this fight ended hours ago." Server implementations must check the
+// encounter's own live state before populating encounter_id; a STARTED
+// lobby whose encounter has ended returns encounter_id empty, same as "no
+// active lobby."
+message GetMyActiveLobbyResponse {
+  string lobby_id = 1;
+  string encounter_id = 2;
+  LobbyStatus lobby_status = 3;
+}
+
 // =============================================================================
 // Service
 // =============================================================================
@@ -145,4 +178,10 @@ service LobbyService {
   // Ends when EncounterStarted fires; clients then subscribe
   // StreamEncounter(encounter_id) instead.
   rpc StreamLobby(StreamLobbyRequest) returns (stream LobbyEvent);
+
+  // GetMyActiveLobby looks up the authenticated caller's own active lobby —
+  // resume-after-refresh support (rpg-dnd5e-web#444). Empty lobby_id means
+  // no active lobby, not an error. encounter_id is only populated when the
+  // lobby is STARTED and the encounter has been verified still live.
+  rpc GetMyActiveLobby(GetMyActiveLobbyRequest) returns (GetMyActiveLobbyResponse);
 }

--- a/dnd5e/api/lobby/v1alpha1/types.proto
+++ b/dnd5e/api/lobby/v1alpha1/types.proto
@@ -6,6 +6,17 @@ option go_package = "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/lobb
 option java_multiple_files = true;
 option java_package = "com.kirkdiggler.rpg.api.dnd5e.lobby.v1alpha1";
 
+// LobbyStatus mirrors the lobby's server-side lifecycle: WAITING -> STARTED
+// is a one-way transition (see StartEncounterRequest in service.proto).
+// Exposed for GetMyActiveLobbyResponse — a STARTED lobby's encounter_id is
+// only trustworthy alongside this status, since STARTED does not by itself
+// mean the encounter is still running (see GetMyActiveLobbyResponse).
+enum LobbyStatus {
+  LOBBY_STATUS_UNSPECIFIED = 0;
+  LOBBY_STATUS_WAITING = 1;
+  LOBBY_STATUS_STARTED = 2;
+}
+
 // LobbyMember is one player's seat in the lobby's party-assembly roster.
 //
 // character_name is server-enriched (looked up from the character store at


### PR DESCRIPTION
## Summary

Adds an additive, non-breaking RPC to `dnd5e.api.lobby.v1alpha1.LobbyService`: `GetMyActiveLobby`, letting a client that has lost all in-memory session state (page reload, crash, cold Discord Activity launch) learn whether it has an active lobby or running encounter to resume into, instead of landing on Home.

Closes #180. Leg 1 of a 3-leg cross-repo chain (protos -> rpg-api -> rpg-dnd5e-web); see #180 for the full plan and rpg-dnd5e-web#444 (https://github.com/KirkDiggler/rpg-dnd5e-web/issues/444) for the root-cause investigation this is built from.

## What's in this PR

- `LobbyStatus` enum in `types.proto` (`WAITING` / `STARTED`), mirroring the repository's existing internal status.
- `GetMyActiveLobbyRequest` (empty — no fields) / `GetMyActiveLobbyResponse` (`lobby_id`, `encounter_id`, `lobby_status`) in `service.proto`.
- `GetMyActiveLobby` RPC on `LobbyService`.

## Load-bearing design decisions (from the #444 investigation)

- **No `player_id` request field.** Identity comes from the authenticated context, matching `StreamLobbyRequest`'s existing pattern — a client-supplied player_id would let a caller query another player's lobby. We just deprecated that exact mistake elsewhere (#178).
- **Empty `lobby_id` is the normal response, not an error.** Every player who isn't currently in a lobby/encounter gets this on every app-mount call — that's the majority case, so error-as-control-flow would be the wrong shape.
- **`encounter_id` is gated on more than `lobby_status == STARTED`.** The lobby record's `STARTED` status is a one-way, terminal transition on the lobby side — nothing marks it when the encounter it points to later ends. So `STARTED` alone can't distinguish "still fighting" from "this fight ended hours ago" within the lobby's TTL window. The response contract requires the server to verify the encounter is still live before populating `encounter_id`; leg 2 (rpg-api) implements that check. This is called out explicitly in both message doc comments so the constraint travels with the contract, not just the design doc.

## Test plan

- [x] `make test` (buf lint, buf format --diff --exit-code, buf generate, mocks) — clean
- [x] Verified generated Go (`gen/go/...`) and TypeScript (`gen/ts/...`) both picked up `GetMyActiveLobby` and `LobbyStatus`
- [x] Verified `gen/` is gitignored — only the two `.proto` source files are committed; codegen lands on the `generated` branch per this repo's normal flow

No Copilot review configured for this repo — this PR body carries the investigation rationale in its place.