### PR TITLE
feat(lobby): add AbandonEncounter RPC — host-only abandon path

### DIFF
--- a/dnd5e/api/lobby/v1alpha1/service.proto
+++ b/dnd5e/api/lobby/v1alpha1/service.proto
@@ -103,6 +103,25 @@ message StartEncounterResponse {
   string encounter_id = 1;
 }
 
+// AbandonEncounterRequest administratively ends the lobby's STARTED
+// encounter — host-only. The escape hatch for a stuck or unwanted encounter
+// (e.g. a FREE_ROAM deadlock) with no other way to end (rpg-api#663).
+//
+// Takes lobby_id, not encounter_id: host authority is modeled on the lobby
+// (host_player_id), matching StartEncounter — the caller doesn't separately
+// know or supply the encounter_id, the server resolves it from the lobby
+// record. Returns FailedPrecondition if the lobby hasn't started an
+// encounter yet (mirrors LeaveLobby's pre-start-only shape, inverted).
+message AbandonEncounterRequest {
+  string lobby_id = 1;
+}
+
+// AbandonEncounterResponse is a lean ack — the terminal transition
+// (EncounterEnded{reason:"abandoned"}) flows via the encounter's existing
+// StreamEncounter channel, the same terminal-transition shape a natural
+// victory/TPK end already uses, not a separate contract of its own.
+message AbandonEncounterResponse {}
+
 // StreamLobbyRequest subscribes to lobby membership events. The subscriber's
 // identity for presence tracking comes from the authenticated context, not a
 // request field (a client-supplied player_id would let a caller flip another
@@ -172,6 +191,13 @@ service LobbyService {
   // is terminal — this is the only way a lobby becomes an encounter, replacing
   // EncounterService.CreateEncounter's single-caller construction path.
   rpc StartEncounter(StartEncounterRequest) returns (StartEncounterResponse);
+
+  // AbandonEncounter administratively ends the lobby's STARTED encounter —
+  // host-only. Publishes EncounterEnded{reason:"abandoned"} on the
+  // encounter's own StreamEncounter channel, the same terminal-transition
+  // shape as a natural victory/TPK end. FailedPrecondition if the lobby
+  // hasn't started an encounter yet. rpg-api#663.
+  rpc AbandonEncounter(AbandonEncounterRequest) returns (AbandonEncounterResponse);
 
   // StreamLobby is the primary state delivery channel — mirrors StreamEncounter's
   // snapshot-then-deltas: the first event on subscribe is always a LobbySnapshot.


### PR DESCRIPTION
## Summary

Adds exactly one RPC to `dnd5e.api.lobby.v1alpha1.LobbyService`: `AbandonEncounter`. Refs rpg-api#663 (https://github.com/KirkDiggler/rpg-api/issues/663). Shape approved by the director ahead of this PR (this repo has no Copilot coverage — flagging for a manual line review per that discussion).

```proto
message AbandonEncounterRequest {
  string lobby_id = 1;
}

message AbandonEncounterResponse {}

rpc AbandonEncounter(AbandonEncounterRequest) returns (AbandonEncounterResponse);
```

## Why this shape

- **Host-only, lobby-scoped, like `StartEncounter`.** Host authority is modeled on the lobby (`host_player_id`), not the encounter — the caller supplies `lobby_id` only; the server resolves the associated `encounter_id` from the lobby record internally, same pattern `StartEncounter` already uses.
- **Empty response — lean ack.** The real state change (`EncounterEnded{reason:"abandoned"}`) flows via the encounter's existing `StreamEncounter` channel. This is the same terminal-transition shape a natural victory/TPK end already publishes (`EncounterEnded.reason` is already a bare string on the wire — no event-contract change needed here), driven server-side by rpg-toolkit#797's `Encounter.End(reason)` (https://github.com/KirkDiggler/rpg-toolkit/issues/797, toolkit PR https://github.com/KirkDiggler/rpg-toolkit/pull/798).
- **No `types.proto` change.** `LobbyStatus` stays `WAITING`/`STARTED` — the ended-encounter signal is carried entirely by the encounter's own `Mode`, which `GetMyActiveLobby`'s existing liveness check already reads.

## What this is NOT

- No rpg-api orchestrator implementation — that's a separate PR (rpg-api#663), pinned to this repo's `generated` branch only once merged.
- No web wiring — separate dispatch.
- No other RPCs, fields, or files touched — kept to exactly this one addition per instruction.

## Verification

- `make test` (buf lint + buf format --diff --exit-code + buf generate + mocks) — clean.
- `make compile-go` — generated Go compiles.
- `gen/` is gitignored in this repo (confirmed via `.gitignore`) — this PR touches only `dnd5e/api/lobby/v1alpha1/service.proto`, no generated output committed.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013gA28TEYiq8UFMqbTZL3K9