### PR TITLE
feat(encounter): additive Wall.id — door addressability

### DIFF
--- a/dnd5e/api/v1alpha2/encounter/types.proto
+++ b/dnd5e/api/v1alpha2/encounter/types.proto
@@ -153,6 +153,9 @@ message Wall {
   Position from = 1;
   Position to = 2;
   WallKind kind = 3;
+  optional string id = 4; // present on interactable walls (doors); the web passes it as
+  // InteractRequest.target_entity_id to bridge a door click to Interact. Absent on plain
+  // solid/window walls, which have nothing to interact with.
 }
 
 // Zone is optional metadata attached to a region of hexes.


### PR DESCRIPTION
Closes #185

## Load-bearing digest
Adds `optional string id = 4` to `dnd5e.api.v1alpha2.encounter.Wall`. This is the click→Interact bridge for doors: the web reads `Wall.id` off a door segment and passes it as `InteractRequest.target_entity_id`, then consumes `DoorOpened`/`DoorClosed` (which already key off `door_entity_id`) to update state. Purely additive, new field tag, no existing field touched.

## Diff
```proto
 message Wall {
   Position from = 1;
   Position to = 2;
   WallKind kind = 3;
+  optional string id = 4; // present on interactable walls (doors); the web passes it as
+  // InteractRequest.target_entity_id to bridge a door click to Interact. Absent on plain
+  // solid/window walls, which have nothing to interact with.
 }
```

## Scope decisions
- `WALL_KIND_DOOR_LOCKED` is deliberately **not** included — that's Slice 3's optional addition per the issue, not this wave's wire change.
- No other `Space`-shape field touched. Nothing subtractive.

## Verification
- `buf lint` — clean (only pre-existing `buf.yaml` DEFAULT-category deprecation warning, unrelated).
- `buf breaking --against origin/main` — passes with no output (confirmed additive, non-breaking).
- `make test` (lint + format check + generate + mocks) — clean.
- `git status` after `buf generate` shows only the `.proto` file changed; all `gen/` output is gitignored per this repo's CI-owns-`generated`-branch workflow.

## Review note
Copilot does not review this repo — a director-commissioned review agent gates this PR before merge-ready. Do not merge without that sign-off.