### PR TITLE
feat(v1alpha2): refgen tool + generated dnd5e Weapon & Armor enums (#190)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,14 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '18'
-      
+
       - uses: bufbuild/buf-setup-action@v1
         with:
           github_token: ${{ github.token }}
-      
+
+      - name: Test refgen tool
+        run: cd tools/refgen && go test ./...
+
       - name: Install mockgen
         run: go install go.uber.org/mock/mockgen@latest
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,15 @@
 # Generated code
 gen/
 
+# refgen tool binary (built via `go build`, never committed)
+/tools/refgen/refgen
+
 # Node.js
 node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .npm
-
-# Go
-*.sum
 
 # IDE
 .vscode/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install-tools lint format generate clean test push
+.PHONY: help install-tools lint format refgen generate clean test push
 
 help: ## Show this help message
 	@echo 'Usage: make [target]'
@@ -16,6 +16,10 @@ lint: ## Lint protobuf files
 	buf lint
 
 format: ## Format protobuf files
+	buf format -w
+
+refgen: ## Regenerate typed content enums (weapons, armor, ...) from the toolkit registry
+	cd tools/refgen && go run .
 	buf format -w
 
 generate: ## Generate Go and TypeScript code

--- a/dnd5e/api/v1alpha2/armor/armor.proto
+++ b/dnd5e/api/v1alpha2/armor/armor.proto
@@ -1,0 +1,31 @@
+// Code generated from rpg-toolkit/rulebooks/dnd5e/armor (armor.All). DO NOT EDIT.
+// Regenerate with: make refgen — source of truth is the toolkit registry.
+//
+// 1-to-1 with armor.All (13 armor pieces).
+
+syntax = "proto3";
+
+package dnd5e.api.v1alpha2.armor;
+
+option go_package = "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/armor;armorpb";
+
+// Armor is the typed identity of a dnd5e armor piece on the wire.
+// Enum value = the toolkit ArmorID; the UI maps it to an asset/behavior.
+// Numbers are STABLE: append-only, never renumbered or reused (wire contract).
+enum Armor {
+  ARMOR_UNSPECIFIED = 0; // unset; never a real armor piece
+
+  ARMOR_BREASTPLATE = 1; // breastplate
+  ARMOR_CHAIN_MAIL = 2; // chain-mail
+  ARMOR_CHAIN_SHIRT = 3; // chain-shirt
+  ARMOR_HALF_PLATE = 4; // half-plate
+  ARMOR_HIDE = 5; // hide
+  ARMOR_LEATHER = 6; // leather
+  ARMOR_PADDED = 7; // padded
+  ARMOR_PLATE = 8; // plate
+  ARMOR_RING_MAIL = 9; // ring-mail
+  ARMOR_SCALE_MAIL = 10; // scale-mail
+  ARMOR_SHIELD = 11; // shield
+  ARMOR_SPLINT = 12; // splint
+  ARMOR_STUDDED_LEATHER = 13; // studded-leather
+}

--- a/dnd5e/api/v1alpha2/weapons/weapons.proto
+++ b/dnd5e/api/v1alpha2/weapons/weapons.proto
@@ -1,0 +1,56 @@
+// Code generated from rpg-toolkit/rulebooks/dnd5e/weapons (weapons.All). DO NOT EDIT.
+// Regenerate with: make refgen — source of truth is the toolkit registry.
+//
+// 1-to-1 with weapons.All (38 concrete weapons); category placeholders simple-weapon/martial-weapon/any-weapon are choice-requirement consts, not weapons, and are intentionally excluded — they aren't in the registry.
+
+syntax = "proto3";
+
+package dnd5e.api.v1alpha2.weapons;
+
+option go_package = "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/weapons;weaponspb";
+
+// Weapon is the typed identity of a dnd5e weapon on the wire.
+// Enum value = the toolkit WeaponID; the UI maps it to an asset/behavior.
+// Numbers are STABLE: append-only, never renumbered or reused (wire contract).
+enum Weapon {
+  WEAPON_UNSPECIFIED = 0; // unset; never a real weapon
+
+  WEAPON_BATTLEAXE = 1; // battleaxe
+  WEAPON_BLOWGUN = 2; // blowgun
+  WEAPON_CLUB = 3; // club
+  WEAPON_DAGGER = 4; // dagger
+  WEAPON_DART = 5; // dart
+  WEAPON_FLAIL = 6; // flail
+  WEAPON_GLAIVE = 7; // glaive
+  WEAPON_GREATAXE = 8; // greataxe
+  WEAPON_GREATCLUB = 9; // greatclub
+  WEAPON_GREATSWORD = 10; // greatsword
+  WEAPON_HALBERD = 11; // halberd
+  WEAPON_HAND_CROSSBOW = 12; // hand-crossbow
+  WEAPON_HANDAXE = 13; // handaxe
+  WEAPON_HEAVY_CROSSBOW = 14; // heavy-crossbow
+  WEAPON_JAVELIN = 15; // javelin
+  WEAPON_LANCE = 16; // lance
+  WEAPON_LIGHT_CROSSBOW = 17; // light-crossbow
+  WEAPON_LIGHT_HAMMER = 18; // light-hammer
+  WEAPON_LONGBOW = 19; // longbow
+  WEAPON_LONGSWORD = 20; // longsword
+  WEAPON_MACE = 21; // mace
+  WEAPON_MAUL = 22; // maul
+  WEAPON_MORNINGSTAR = 23; // morningstar
+  WEAPON_NET = 24; // net
+  WEAPON_PIKE = 25; // pike
+  WEAPON_QUARTERSTAFF = 26; // quarterstaff
+  WEAPON_RAPIER = 27; // rapier
+  WEAPON_SCIMITAR = 28; // scimitar
+  WEAPON_SHORTBOW = 29; // shortbow
+  WEAPON_SHORTSWORD = 30; // shortsword
+  WEAPON_SICKLE = 31; // sickle
+  WEAPON_SLING = 32; // sling
+  WEAPON_SPEAR = 33; // spear
+  WEAPON_TRIDENT = 34; // trident
+  WEAPON_UNARMED_STRIKE = 35; // unarmed-strike
+  WEAPON_WAR_PICK = 36; // war-pick
+  WEAPON_WARHAMMER = 37; // warhammer
+  WEAPON_WHIP = 38; // whip
+}

--- a/tools/refgen/go.mod
+++ b/tools/refgen/go.mod
@@ -1,0 +1,7 @@
+module github.com/KirkDiggler/rpg-api-protos/tools/refgen
+
+go 1.25.3
+
+require github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.66.0
+
+require github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 // indirect

--- a/tools/refgen/go.sum
+++ b/tools/refgen/go.sum
@@ -1,0 +1,12 @@
+github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
+github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.66.0 h1:p2MiKPF5tr35HhBe+o28/FBF1EXRQXh5w1l/ZtP5pAU=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.66.0/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tools/refgen/main.go
+++ b/tools/refgen/main.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/armor"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+)
+
+func main() {
+	root, err := findRepoRoot(".")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "refgen: %v\n", err)
+		os.Exit(1)
+	}
+
+	categories := []Category{
+		weaponsCategory(),
+		armorCategory(),
+	}
+
+	for _, c := range categories {
+		if err := Generate(root, c); err != nil {
+			fmt.Fprintf(os.Stderr, "refgen: %s: %v\n", c.Name, err)
+			os.Exit(1)
+		}
+		fmt.Printf("refgen: wrote %s (%d ids)\n", c.OutFile, len(c.IDs))
+	}
+}
+
+// weaponsCategory sources the Weapon enum from weapons.All — the registry
+// map, not the WeaponID consts. common.go also declares category
+// placeholders (AnySimpleWeapon, AnyMartialWeapon, AnyWeapon) for choice
+// requirements; those are intentionally NOT in weapons.All and so never reach
+// the wire as weapon identities.
+func weaponsCategory() Category {
+	ids := make([]string, 0, len(weapons.All))
+	for id := range weapons.All {
+		ids = append(ids, string(id))
+	}
+	return Category{
+		Name:           "weapons",
+		RegistrySource: "rpg-toolkit/rulebooks/dnd5e/weapons (weapons.All)",
+		RegistryRef:    "weapons.All",
+		Noun:           "concrete weapons",
+		HeaderNote:     "category placeholders simple-weapon/martial-weapon/any-weapon are choice-requirement consts, not weapons, and are intentionally excluded — they aren't in the registry",
+		EnumName:       "Weapon",
+		EnumComment: []string{
+			"Weapon is the typed identity of a dnd5e weapon on the wire.",
+			"Enum value = the toolkit WeaponID; the UI maps it to an asset/behavior.",
+			"Numbers are STABLE: append-only, never renumbered or reused (wire contract).",
+		},
+		Prefix:        "WEAPON_",
+		UnspecComment: "unset; never a real weapon",
+		ProtoPackage:  "dnd5e.api.v1alpha2.weapons",
+		GoPackage:     "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/weapons;weaponspb",
+		OutFile:       "dnd5e/api/v1alpha2/weapons/weapons.proto",
+		RegenerateCmd: "make refgen",
+		IDs:           ids,
+	}
+}
+
+// armorCategory sources the Armor enum from armor.All. Unlike weapons, the
+// armor package declares no category placeholders — every ArmorID const is
+// already a concrete, equippable piece of armor in the registry.
+func armorCategory() Category {
+	ids := make([]string, 0, len(armor.All))
+	for id := range armor.All {
+		ids = append(ids, string(id))
+	}
+	return Category{
+		Name:           "armor",
+		RegistrySource: "rpg-toolkit/rulebooks/dnd5e/armor (armor.All)",
+		RegistryRef:    "armor.All",
+		Noun:           "armor pieces",
+		EnumName:       "Armor",
+		EnumComment: []string{
+			"Armor is the typed identity of a dnd5e armor piece on the wire.",
+			"Enum value = the toolkit ArmorID; the UI maps it to an asset/behavior.",
+			"Numbers are STABLE: append-only, never renumbered or reused (wire contract).",
+		},
+		Prefix:        "ARMOR_",
+		UnspecComment: "unset; never a real armor piece",
+		ProtoPackage:  "dnd5e.api.v1alpha2.armor",
+		GoPackage:     "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/armor;armorpb",
+		OutFile:       "dnd5e/api/v1alpha2/armor/armor.proto",
+		RegenerateCmd: "make refgen",
+		IDs:           ids,
+	}
+}

--- a/tools/refgen/refgen.go
+++ b/tools/refgen/refgen.go
@@ -6,6 +6,15 @@
 // keys. The core contract (see Generate) is enum-number stability: once a
 // registry id has a wire number, that number never changes, is never reused,
 // and is never assigned to a different id.
+//
+// The generated .proto file IS the number ledger — there is no separate
+// history file. Every past assignment is either an active value or a
+// `reserved <n>;` line; Generate() only ever reads that state back out of
+// the file it last wrote. This means the DO-NOT-EDIT header is doing real
+// work: hand-deleting a `reserved` line (or an active value, without going
+// through the registry) would let Generate() believe that number was never
+// used and hand it out again. Known limitation, not enforced by the tool —
+// don't hand-edit generated files.
 package main
 
 import (
@@ -65,8 +74,13 @@ type Category struct {
 	IDs []string
 }
 
-// reservedEntry is one retired enum value: its number and name are never
-// reused.
+// reservedEntry is one retired enum value: its number is never reused. Name
+// is the id's former enum value name, kept only as a human-readable trailing
+// comment — it is NOT emitted as a proto `reserved "name";` statement. Proto
+// value names are 1:1 with registry ids, so if a retired id later reappears
+// in the registry it regenerates that exact same name; reserving the name
+// itself would make the reappearing id's own value collide with the
+// reservation and fail to compile. Only the number is a permanent well.
 type reservedEntry struct {
 	Number int32
 	Name   string
@@ -161,16 +175,31 @@ func Generate(repoRoot string, c Category) error {
 	return nil
 }
 
+// validateCategory checks c is well-formed and that every id produces a
+// unique, non-conflicting enum value name — cheap to check up front since
+// value names are a pure function of Prefix + id, independent of any
+// existing file state.
 func validateCategory(c Category) error {
 	if c.Name == "" || c.EnumName == "" || c.Prefix == "" || c.OutFile == "" {
 		return fmt.Errorf("Name, EnumName, Prefix, and OutFile are required")
 	}
-	seen := make(map[string]bool, len(c.IDs))
+	unspecName := c.Prefix + "UNSPECIFIED"
+	seenIDs := make(map[string]bool, len(c.IDs))
+	nameOwner := make(map[string]string, len(c.IDs))
 	for _, id := range c.IDs {
-		if seen[id] {
+		if seenIDs[id] {
 			return fmt.Errorf("duplicate registry id %q", id)
 		}
-		seen[id] = true
+		seenIDs[id] = true
+
+		name := c.Prefix + upperSnake(id)
+		if name == unspecName {
+			return fmt.Errorf("id %q generates enum value name %s, which collides with the UNSPECIFIED value", id, unspecName)
+		}
+		if other, ok := nameOwner[name]; ok {
+			return fmt.Errorf("ids %q and %q both generate enum value name %s", other, id, name)
+		}
+		nameOwner[name] = id
 	}
 	return nil
 }
@@ -211,8 +240,11 @@ func render(c Category, values []valueEntry, reserved []reservedEntry) string {
 	if len(reserved) > 0 {
 		b.WriteString("\n")
 		for _, r := range reserved {
-			fmt.Fprintf(&b, "  reserved %d;\n", r.Number)
-			fmt.Fprintf(&b, "  reserved %q;\n", r.Name)
+			if r.Name != "" {
+				fmt.Fprintf(&b, "  reserved %d; // %s\n", r.Number, r.Name)
+			} else {
+				fmt.Fprintf(&b, "  reserved %d;\n", r.Number)
+			}
 		}
 	}
 
@@ -228,11 +260,47 @@ func render(c Category, values []valueEntry, reserved []reservedEntry) string {
 }
 
 var (
-	enumStartRe    = regexp.MustCompile(`^enum\s+(\w+)\s*\{\s*$`)
-	valueLineRe    = regexp.MustCompile(`^(\w+)\s*=\s*(-?\d+)\s*;\s*(?://\s*(.*))?$`)
-	reservedNumRe  = regexp.MustCompile(`^reserved\s+(\d+)\s*;\s*$`)
-	reservedNameRe = regexp.MustCompile(`^reserved\s+"([^"]*)"\s*;\s*$`)
+	enumStartRe = regexp.MustCompile(`^enum\s+(\w+)\s*\{\s*$`)
+	valueLineRe = regexp.MustCompile(`^(\w+)\s*=\s*(-?\d+)\s*;\s*(?://\s*(.*))?$`)
+	// reservedLineRe matches a numeric `reserved` statement — never a
+	// `reserved "NAME";` name statement (those start with a quote, not a
+	// digit, and are deliberately left unrecognized: this tool never emits
+	// them — see reservedEntry). Tolerates the comma/`to`-range forms buf
+	// format or a human might use, e.g. "2, 3" or "2 to 5".
+	reservedLineRe = regexp.MustCompile(`^reserved\s+(\d[^;]*);\s*(?://\s*(.*))?$`)
 )
+
+// parseReservedNumbers expands a reserved-statement body ("2", "2, 3", or
+// "2 to 5", freely mixed) into individual numbers.
+func parseReservedNumbers(spec string) ([]int32, error) {
+	var nums []int32
+	for _, part := range strings.Split(spec, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if lo, hi, ok := strings.Cut(part, " to "); ok {
+			loN, err := strconv.ParseInt(strings.TrimSpace(lo), 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("parsing reserved range start %q: %w", lo, err)
+			}
+			hiN, err := strconv.ParseInt(strings.TrimSpace(hi), 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("parsing reserved range end %q: %w", hi, err)
+			}
+			for n := loN; n <= hiN; n++ {
+				nums = append(nums, int32(n))
+			}
+			continue
+		}
+		n, err := strconv.ParseInt(part, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("parsing reserved number %q: %w", part, err)
+		}
+		nums = append(nums, int32(n))
+	}
+	return nums, nil
+}
 
 // parseExisting reads outPath (if it exists) and extracts the current
 // id->value assignments and reserved entries for c's enum. A missing file is
@@ -248,7 +316,6 @@ func parseExisting(outPath string, c Category) (map[string]valueEntry, []reserve
 
 	values := map[string]valueEntry{}
 	var reserved []reservedEntry
-	var pendingReservedNum *int32
 
 	inEnum := false
 	unspecName := c.Prefix + "UNSPECIFIED"
@@ -271,21 +338,15 @@ func parseExisting(outPath string, c Category) (map[string]valueEntry, []reserve
 			continue
 		}
 
-		if m := reservedNumRe.FindStringSubmatch(line); m != nil {
-			n, err := strconv.ParseInt(m[1], 10, 32)
+		if m := reservedLineRe.FindStringSubmatch(line); m != nil {
+			nums, err := parseReservedNumbers(m[1])
 			if err != nil {
-				return nil, nil, fmt.Errorf("parsing reserved number %q: %w", line, err)
+				return nil, nil, fmt.Errorf("parsing reserved line %q: %w", line, err)
 			}
-			num := int32(n)
-			pendingReservedNum = &num
-			continue
-		}
-		if m := reservedNameRe.FindStringSubmatch(line); m != nil {
-			if pendingReservedNum == nil {
-				return nil, nil, fmt.Errorf("reserved name %q with no preceding reserved number", line)
+			comment := strings.TrimSpace(m[2])
+			for _, n := range nums {
+				reserved = append(reserved, reservedEntry{Number: n, Name: comment})
 			}
-			reserved = append(reserved, reservedEntry{Number: *pendingReservedNum, Name: m[1]})
-			pendingReservedNum = nil
 			continue
 		}
 
@@ -311,10 +372,6 @@ func parseExisting(outPath string, c Category) (map[string]valueEntry, []reserve
 				"value %s (id %q) doesn't match expected generated name %s — file may be hand-edited", name, id, wantName)
 		}
 		values[id] = valueEntry{ID: id, Name: name, Number: int32(n)}
-	}
-
-	if pendingReservedNum != nil {
-		return nil, nil, fmt.Errorf("reserved number %d has no matching reserved name statement", *pendingReservedNum)
 	}
 
 	return values, reserved, nil

--- a/tools/refgen/refgen.go
+++ b/tools/refgen/refgen.go
@@ -1,0 +1,340 @@
+// Package main implements refgen: a codegen tool that generates proto content
+// enums 1-to-1 from a rpg-toolkit registry.
+//
+// The tool never touches proto business logic — it only maintains a single
+// enum per configured Category, sourced from that category's registry map
+// keys. The core contract (see Generate) is enum-number stability: once a
+// registry id has a wire number, that number never changes, is never reused,
+// and is never assigned to a different id.
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Category configures one registry -> one generated proto enum.
+type Category struct {
+	// Name identifies the category in tool output (e.g. "weapons").
+	Name string
+	// RegistrySource describes where the ids come from, e.g.
+	// "rpg-toolkit/rulebooks/dnd5e/weapons (weapons.All)". Used in the file
+	// header.
+	RegistrySource string
+	// RegistryRef is the short registry reference used in the "1-to-1 with"
+	// summary line, e.g. "weapons.All".
+	RegistryRef string
+	// Noun names one registry entry for the summary line, e.g. "concrete
+	// weapons" or "armor pieces".
+	Noun string
+	// HeaderNote is an optional extra clause appended to the summary line,
+	// e.g. explaining excluded category placeholders. Leave empty if there's
+	// nothing to call out.
+	HeaderNote string
+
+	// EnumName is the proto enum name, e.g. "Weapon".
+	EnumName string
+	// EnumComment is the doc comment placed directly above the enum. Each
+	// element becomes one "// " line.
+	EnumComment []string
+	// Prefix is prepended to every value name, e.g. "WEAPON_".
+	Prefix string
+	// UnspecComment is the trailing comment on the generated
+	// "<PREFIX>UNSPECIFIED = 0" value.
+	UnspecComment string
+
+	// ProtoPackage is the proto package statement, e.g.
+	// "dnd5e.api.v1alpha2.weapons".
+	ProtoPackage string
+	// GoPackage is the full go_package option value, e.g.
+	// "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/weapons;weaponspb".
+	GoPackage string
+	// OutFile is the repo-root-relative path to the generated .proto file.
+	OutFile string
+	// RegenerateCmd is the command documented in the header for regenerating
+	// this file, e.g. "make refgen".
+	RegenerateCmd string
+
+	// IDs are the registry's current keys (toolkit ids, e.g. "battleaxe").
+	// Order doesn't matter — Generate sorts them.
+	IDs []string
+}
+
+// reservedEntry is one retired enum value: its number and name are never
+// reused.
+type reservedEntry struct {
+	Number int32
+	Name   string
+}
+
+// valueEntry is one active enum value.
+type valueEntry struct {
+	ID     string
+	Name   string
+	Number int32
+}
+
+// Generate reads the existing proto file for c (if any), reconciles it
+// against c.IDs, and (re)writes it under repoRoot. Numbering is append-only:
+// existing id->number assignments are preserved, new ids get the next free
+// number (sorted among themselves for determinism), and ids no longer in the
+// registry become reserved rather than deleted or renumbered.
+func Generate(repoRoot string, c Category) error {
+	if err := validateCategory(c); err != nil {
+		return fmt.Errorf("invalid category %q: %w", c.Name, err)
+	}
+
+	outPath := filepath.Join(repoRoot, filepath.FromSlash(c.OutFile))
+
+	existingValues, existingReserved, err := parseExisting(outPath, c)
+	if err != nil {
+		return fmt.Errorf("parsing existing %s: %w", c.OutFile, err)
+	}
+
+	ids := append([]string(nil), c.IDs...)
+	sort.Strings(ids)
+	idSet := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		idSet[id] = true
+	}
+
+	// usedNumbers tracks every number ever handed out (active or reserved) so
+	// it's never reassigned.
+	usedNumbers := make(map[int32]bool)
+	for _, v := range existingValues {
+		usedNumbers[v.Number] = true
+	}
+	for _, r := range existingReserved {
+		usedNumbers[r.Number] = true
+	}
+
+	// Ids that were active before but have dropped out of the registry
+	// become newly reserved.
+	reserved := append([]reservedEntry(nil), existingReserved...)
+	kept := make(map[string]valueEntry, len(existingValues))
+	for id, v := range existingValues {
+		if idSet[id] {
+			kept[id] = v
+			continue
+		}
+		reserved = append(reserved, reservedEntry{Number: v.Number, Name: v.Name})
+	}
+
+	// Assign numbers to ids new to the registry, in sorted order, using the
+	// next number past everything ever used. 0 is permanently reserved for
+	// <PREFIX>UNSPECIFIED, so numbering always starts at 1.
+	nextNumber := int32(1)
+	for n := range usedNumbers {
+		if n >= nextNumber {
+			nextNumber = n + 1
+		}
+	}
+
+	values := make([]valueEntry, 0, len(ids))
+	for _, id := range ids {
+		if v, ok := kept[id]; ok {
+			values = append(values, v)
+			continue
+		}
+		name := c.Prefix + upperSnake(id)
+		values = append(values, valueEntry{ID: id, Name: name, Number: nextNumber})
+		usedNumbers[nextNumber] = true
+		nextNumber++
+	}
+
+	sort.Slice(values, func(i, j int) bool { return values[i].Number < values[j].Number })
+	sort.Slice(reserved, func(i, j int) bool { return reserved[i].Number < reserved[j].Number })
+
+	content := render(c, values, reserved)
+
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		return fmt.Errorf("creating output dir: %w", err)
+	}
+	if err := os.WriteFile(outPath, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", c.OutFile, err)
+	}
+	return nil
+}
+
+func validateCategory(c Category) error {
+	if c.Name == "" || c.EnumName == "" || c.Prefix == "" || c.OutFile == "" {
+		return fmt.Errorf("Name, EnumName, Prefix, and OutFile are required")
+	}
+	seen := make(map[string]bool, len(c.IDs))
+	for _, id := range c.IDs {
+		if seen[id] {
+			return fmt.Errorf("duplicate registry id %q", id)
+		}
+		seen[id] = true
+	}
+	return nil
+}
+
+// upperSnake converts a toolkit id (hyphenated lower-kebab) into the
+// SCREAMING_SNAKE suffix used in enum value names.
+// e.g. "light-crossbow" -> "LIGHT_CROSSBOW".
+func upperSnake(id string) string {
+	return strings.ToUpper(strings.ReplaceAll(id, "-", "_"))
+}
+
+// render produces the full .proto file content for c. Output is plain
+// (single-space) proto formatting; `buf format -w` is the source of truth for
+// final layout and is run as a separate step.
+func render(c Category, values []valueEntry, reserved []reservedEntry) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "// Code generated from %s. DO NOT EDIT.\n", c.RegistrySource)
+	fmt.Fprintf(&b, "// Regenerate with: %s — source of truth is the toolkit registry.\n", c.RegenerateCmd)
+	b.WriteString("//\n")
+	summary := fmt.Sprintf("1-to-1 with %s (%d %s)", c.RegistryRef, len(values), c.Noun)
+	if c.HeaderNote != "" {
+		summary += "; " + c.HeaderNote
+	}
+	fmt.Fprintf(&b, "// %s.\n", summary)
+	b.WriteString("\n")
+
+	b.WriteString("syntax = \"proto3\";\n\n")
+	fmt.Fprintf(&b, "package %s;\n\n", c.ProtoPackage)
+	fmt.Fprintf(&b, "option go_package = \"%s\";\n\n", c.GoPackage)
+
+	for _, line := range c.EnumComment {
+		fmt.Fprintf(&b, "// %s\n", line)
+	}
+	fmt.Fprintf(&b, "enum %s {\n", c.EnumName)
+	fmt.Fprintf(&b, "  %sUNSPECIFIED = 0; // %s\n", c.Prefix, c.UnspecComment)
+
+	if len(reserved) > 0 {
+		b.WriteString("\n")
+		for _, r := range reserved {
+			fmt.Fprintf(&b, "  reserved %d;\n", r.Number)
+			fmt.Fprintf(&b, "  reserved %q;\n", r.Name)
+		}
+	}
+
+	if len(values) > 0 {
+		b.WriteString("\n")
+		for _, v := range values {
+			fmt.Fprintf(&b, "  %s = %d; // %s\n", v.Name, v.Number, v.ID)
+		}
+	}
+
+	b.WriteString("}\n")
+	return b.String()
+}
+
+var (
+	enumStartRe    = regexp.MustCompile(`^enum\s+(\w+)\s*\{\s*$`)
+	valueLineRe    = regexp.MustCompile(`^(\w+)\s*=\s*(-?\d+)\s*;\s*(?://\s*(.*))?$`)
+	reservedNumRe  = regexp.MustCompile(`^reserved\s+(\d+)\s*;\s*$`)
+	reservedNameRe = regexp.MustCompile(`^reserved\s+"([^"]*)"\s*;\s*$`)
+)
+
+// parseExisting reads outPath (if it exists) and extracts the current
+// id->value assignments and reserved entries for c's enum. A missing file is
+// not an error — it just means this is the first run.
+func parseExisting(outPath string, c Category) (map[string]valueEntry, []reservedEntry, error) {
+	raw, err := os.ReadFile(outPath)
+	if os.IsNotExist(err) {
+		return map[string]valueEntry{}, nil, nil
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	values := map[string]valueEntry{}
+	var reserved []reservedEntry
+	var pendingReservedNum *int32
+
+	inEnum := false
+	unspecName := c.Prefix + "UNSPECIFIED"
+
+	for _, raw := range strings.Split(string(raw), "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+
+		if !inEnum {
+			if m := enumStartRe.FindStringSubmatch(line); m != nil && m[1] == c.EnumName {
+				inEnum = true
+			}
+			continue
+		}
+
+		if line == "}" {
+			inEnum = false
+			continue
+		}
+
+		if m := reservedNumRe.FindStringSubmatch(line); m != nil {
+			n, err := strconv.ParseInt(m[1], 10, 32)
+			if err != nil {
+				return nil, nil, fmt.Errorf("parsing reserved number %q: %w", line, err)
+			}
+			num := int32(n)
+			pendingReservedNum = &num
+			continue
+		}
+		if m := reservedNameRe.FindStringSubmatch(line); m != nil {
+			if pendingReservedNum == nil {
+				return nil, nil, fmt.Errorf("reserved name %q with no preceding reserved number", line)
+			}
+			reserved = append(reserved, reservedEntry{Number: *pendingReservedNum, Name: m[1]})
+			pendingReservedNum = nil
+			continue
+		}
+
+		m := valueLineRe.FindStringSubmatch(line)
+		if m == nil {
+			return nil, nil, fmt.Errorf("unrecognized line inside enum %s: %q", c.EnumName, line)
+		}
+		name := m[1]
+		n, err := strconv.ParseInt(m[2], 10, 32)
+		if err != nil {
+			return nil, nil, fmt.Errorf("parsing value number %q: %w", line, err)
+		}
+		if name == unspecName {
+			continue
+		}
+		id := strings.TrimSpace(m[3])
+		if id == "" {
+			return nil, nil, fmt.Errorf("value line missing trailing '// <id>' comment: %q", line)
+		}
+		wantName := c.Prefix + upperSnake(id)
+		if wantName != name {
+			return nil, nil, fmt.Errorf(
+				"value %s (id %q) doesn't match expected generated name %s — file may be hand-edited", name, id, wantName)
+		}
+		values[id] = valueEntry{ID: id, Name: name, Number: int32(n)}
+	}
+
+	if pendingReservedNum != nil {
+		return nil, nil, fmt.Errorf("reserved number %d has no matching reserved name statement", *pendingReservedNum)
+	}
+
+	return values, reserved, nil
+}
+
+// findRepoRoot walks up from start looking for the buf.yaml marker file that
+// identifies the rpg-api-protos repo root.
+func findRepoRoot(start string) (string, error) {
+	dir, err := filepath.Abs(start)
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "buf.yaml")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("no buf.yaml found walking up from %s", start)
+		}
+		dir = parent
+	}
+}

--- a/tools/refgen/refgen_test.go
+++ b/tools/refgen/refgen_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -43,6 +44,28 @@ func readOut(t *testing.T, root string, c Category) string {
 		t.Fatal(err)
 	}
 	return string(b)
+}
+
+// requireBuf skips the test if the buf CLI isn't on PATH — the compile-check
+// tests shell out to the real `buf build` to catch what number/name
+// bookkeeping alone can't: whether the generated proto is actually valid.
+func requireBuf(t *testing.T) string {
+	t.Helper()
+	path, err := exec.LookPath("buf")
+	if err != nil {
+		t.Skip("buf CLI not found on PATH; skipping compile-check")
+	}
+	return path
+}
+
+// bufBuild runs `buf build` against root (which setupRoot seeded with a
+// minimal buf.yaml) and returns its combined output alongside any error.
+func bufBuild(t *testing.T, bufPath, root string) (string, error) {
+	t.Helper()
+	cmd := exec.Command(bufPath, "build")
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	return string(out), err
 }
 
 func TestGenerate_FirstRun_SortedByIDStartingAtOne(t *testing.T) {
@@ -207,6 +230,133 @@ func TestGenerate_RejectsDuplicateIDs(t *testing.T) {
 	c := testCategory("alpha", "alpha")
 	if err := Generate(root, c); err == nil {
 		t.Fatal("expected error for duplicate registry ids")
+	}
+}
+
+// TestGenerate_RemovedID_ProtoCompiles is a compile-check: bookkeeping
+// numbers matching what we expect isn't enough — the generated file has to
+// actually be valid protobuf. Runs the real `buf build`.
+func TestGenerate_RemovedID_ProtoCompiles(t *testing.T) {
+	bufPath := requireBuf(t)
+	root := setupRoot(t)
+
+	c := testCategory("alpha", "beta", "gamma")
+	if err := Generate(root, c); err != nil {
+		t.Fatal(err)
+	}
+	c2 := testCategory("alpha", "beta") // gamma removed
+	if err := Generate(root, c2); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := bufBuild(t, bufPath, root)
+	if err != nil {
+		t.Fatalf("generated proto does not compile after a removal:\n%s\n%s", readOut(t, root, c), out)
+	}
+}
+
+// TestGenerate_RemovedThenReintroducedID_ProtoCompiles is the tricky case a
+// pure number-bookkeeping test can miss entirely: if a retired id's OLD name
+// were reserved (not just its number), the id reappearing later would
+// regenerate that exact name and collide with its own reservation, and buf
+// build would fail even though the numbers all looked correct. This is a
+// regression test for that exact failure mode.
+func TestGenerate_RemovedThenReintroducedID_ProtoCompiles(t *testing.T) {
+	bufPath := requireBuf(t)
+	root := setupRoot(t)
+
+	c := testCategory("alpha", "beta")
+	if err := Generate(root, c); err != nil {
+		t.Fatal(err)
+	}
+	c2 := testCategory("alpha") // beta removed
+	if err := Generate(root, c2); err != nil {
+		t.Fatal(err)
+	}
+	c3 := testCategory("alpha", "beta") // beta reintroduced
+	if err := Generate(root, c3); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := bufBuild(t, bufPath, root)
+	if err != nil {
+		t.Fatalf("generated proto does not compile after remove+reintroduce:\n%s\n%s", readOut(t, root, c), out)
+	}
+}
+
+func TestGenerate_RejectsCollidingGeneratedNames(t *testing.T) {
+	root := setupRoot(t)
+	// "foo-bar" and "foo_bar" both normalize to WIDGET_FOO_BAR.
+	c := testCategory("foo-bar", "foo_bar")
+	if err := Generate(root, c); err == nil {
+		t.Fatal("expected error for ids that generate the same enum value name")
+	}
+}
+
+func TestGenerate_RejectsIDCollidingWithUnspecified(t *testing.T) {
+	root := setupRoot(t)
+	c := testCategory("unspecified")
+	if err := Generate(root, c); err == nil {
+		t.Fatal("expected error for an id that generates the UNSPECIFIED name")
+	}
+}
+
+// TestGenerate_TolerantOfCoalescedReservedForms guards parseExisting against
+// wedging on `reserved` statement shapes this tool never emits itself
+// (comma lists, "to" ranges) but that a future buf version or a hand-applied
+// fix might introduce.
+func TestGenerate_TolerantOfCoalescedReservedForms(t *testing.T) {
+	root := setupRoot(t)
+	c := testCategory("alpha")
+	proto := `// Code generated. DO NOT EDIT.
+
+syntax = "proto3";
+
+package test.widgets;
+
+option go_package = "example.com/gen/go/test/widgets;widgetspb";
+
+enum Widget {
+  WIDGET_UNSPECIFIED = 0; // unset
+
+  reserved 2, 3;
+  reserved 5 to 7;
+
+  WIDGET_ALPHA = 1; // alpha
+}
+`
+	if err := os.WriteFile(filepath.Join(root, c.OutFile), []byte(proto), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, reserved, err := parseExisting(filepath.Join(root, c.OutFile), c)
+	if err != nil {
+		t.Fatalf("parseExisting rejected a valid coalesced reserved form: %v", err)
+	}
+	got := make(map[int32]bool, len(reserved))
+	for _, r := range reserved {
+		got[r.Number] = true
+	}
+	for _, want := range []int32{2, 3, 5, 6, 7} {
+		if !got[want] {
+			t.Errorf("expected reserved number %d to be parsed out of the coalesced forms, got %+v", want, reserved)
+		}
+	}
+
+	// And Generate() must keep those numbers off-limits for a brand new id.
+	c2 := testCategory("alpha", "beta")
+	if err := Generate(root, c2); err != nil {
+		t.Fatal(err)
+	}
+	values, _, err := parseExisting(filepath.Join(root, c.OutFile), c2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[values["beta"].Number] {
+		t.Fatalf("beta was assigned a number reserved via a coalesced form: %d", values["beta"].Number)
+	}
+	if values["beta"].Number != 8 {
+		t.Fatalf("expected beta to get number 8 (first free past the coalesced reservations), got %d", values["beta"].Number)
 	}
 }
 

--- a/tools/refgen/refgen_test.go
+++ b/tools/refgen/refgen_test.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// testCategory returns a minimal Category for exercising Generate() without
+// depending on any real toolkit registry.
+func testCategory(ids ...string) Category {
+	return Category{
+		Name:           "widgets",
+		RegistrySource: "test/widgets (widgets.All)",
+		RegistryRef:    "widgets.All",
+		Noun:           "widgets",
+		EnumName:       "Widget",
+		EnumComment:    []string{"Widget is a test enum."},
+		Prefix:         "WIDGET_",
+		UnspecComment:  "unset",
+		ProtoPackage:   "test.widgets",
+		GoPackage:      "example.com/gen/go/test/widgets;widgetspb",
+		OutFile:        "widgets.proto",
+		RegenerateCmd:  "make refgen",
+		IDs:            ids,
+	}
+}
+
+func setupRoot(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "buf.yaml"), []byte("version: v2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func readOut(t *testing.T, root string, c Category) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(root, c.OutFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+func TestGenerate_FirstRun_SortedByIDStartingAtOne(t *testing.T) {
+	root := setupRoot(t)
+	c := testCategory("gamma", "alpha", "beta")
+
+	if err := Generate(root, c); err != nil {
+		t.Fatal(err)
+	}
+
+	values, reserved, err := parseExisting(filepath.Join(root, c.OutFile), c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reserved) != 0 {
+		t.Fatalf("expected no reserved entries, got %v", reserved)
+	}
+	want := map[string]int32{"alpha": 1, "beta": 2, "gamma": 3}
+	for id, num := range want {
+		if values[id].Number != num {
+			t.Errorf("id %q: got number %d, want %d", id, values[id].Number, num)
+		}
+	}
+}
+
+func TestGenerate_Idempotent(t *testing.T) {
+	root := setupRoot(t)
+	c := testCategory("gamma", "alpha", "beta")
+
+	if err := Generate(root, c); err != nil {
+		t.Fatal(err)
+	}
+	first := readOut(t, root, c)
+
+	if err := Generate(root, c); err != nil {
+		t.Fatal(err)
+	}
+	second := readOut(t, root, c)
+
+	if first != second {
+		t.Fatalf("Generate is not idempotent:\n--- first ---\n%s\n--- second ---\n%s", first, second)
+	}
+}
+
+func TestGenerate_AppendsNewIDsWithNextNumber(t *testing.T) {
+	root := setupRoot(t)
+	c := testCategory("alpha", "beta")
+	if err := Generate(root, c); err != nil {
+		t.Fatal(err)
+	}
+
+	c2 := testCategory("alpha", "beta", "delta", "charlie")
+	if err := Generate(root, c2); err != nil {
+		t.Fatal(err)
+	}
+
+	values, _, err := parseExisting(filepath.Join(root, c.OutFile), c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if values["alpha"].Number != 1 || values["beta"].Number != 2 {
+		t.Fatalf("existing ids were renumbered: %+v", values)
+	}
+	// New ids get the next free numbers, sorted among themselves.
+	if values["charlie"].Number != 3 || values["delta"].Number != 4 {
+		t.Fatalf("new ids not assigned sorted next numbers: %+v", values)
+	}
+}
+
+func TestGenerate_RemovedIDBecomesReserved_NeverRenumbered(t *testing.T) {
+	root := setupRoot(t)
+	c := testCategory("alpha", "beta", "gamma")
+	if err := Generate(root, c); err != nil {
+		t.Fatal(err)
+	}
+
+	// gamma drops out of the registry.
+	c2 := testCategory("alpha", "beta")
+	if err := Generate(root, c2); err != nil {
+		t.Fatal(err)
+	}
+
+	values, reserved, err := parseExisting(filepath.Join(root, c.OutFile), c2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := values["gamma"]; ok {
+		t.Fatalf("removed id gamma should not be an active value")
+	}
+	if len(reserved) != 1 || reserved[0].Number != 3 || reserved[0].Name != "WIDGET_GAMMA" {
+		t.Fatalf("expected gamma's number 3 reserved, got %+v", reserved)
+	}
+
+	// A brand new id introduced later must NOT reuse the reserved number.
+	c3 := testCategory("alpha", "beta", "delta")
+	if err := Generate(root, c3); err != nil {
+		t.Fatal(err)
+	}
+	values, reserved, err = parseExisting(filepath.Join(root, c.OutFile), c3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if values["delta"].Number == 3 {
+		t.Fatalf("delta reused reserved number 3")
+	}
+	if values["delta"].Number != 4 {
+		t.Fatalf("expected delta to get number 4, got %d", values["delta"].Number)
+	}
+	if len(reserved) != 1 || reserved[0].Number != 3 {
+		t.Fatalf("reserved entry for gamma should be untouched: %+v", reserved)
+	}
+}
+
+func TestGenerate_RemovedThenReintroducedID_GetsFreshNumber(t *testing.T) {
+	root := setupRoot(t)
+	c := testCategory("alpha", "beta")
+	if err := Generate(root, c); err != nil {
+		t.Fatal(err)
+	}
+
+	c2 := testCategory("alpha") // beta removed
+	if err := Generate(root, c2); err != nil {
+		t.Fatal(err)
+	}
+
+	c3 := testCategory("alpha", "beta") // beta reappears
+	if err := Generate(root, c3); err != nil {
+		t.Fatal(err)
+	}
+
+	values, reserved, err := parseExisting(filepath.Join(root, c.OutFile), c3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if values["beta"].Number == 2 {
+		t.Fatalf("reintroduced id reused its old (now-reserved) number")
+	}
+	if values["beta"].Number != 3 {
+		t.Fatalf("expected reintroduced beta to get fresh number 3, got %d", values["beta"].Number)
+	}
+	if len(reserved) != 1 || reserved[0].Number != 2 || reserved[0].Name != "WIDGET_BETA" {
+		t.Fatalf("original reservation for beta's old number must remain: %+v", reserved)
+	}
+}
+
+func TestGenerate_HyphenatedIDConvertsToUpperSnake(t *testing.T) {
+	root := setupRoot(t)
+	c := testCategory("light-crossbow", "studded-leather")
+	if err := Generate(root, c); err != nil {
+		t.Fatal(err)
+	}
+	out := readOut(t, root, c)
+	for _, want := range []string{"WIDGET_LIGHT_CROSSBOW", "WIDGET_STUDDED_LEATHER"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output:\n%s", want, out)
+		}
+	}
+}
+
+func TestGenerate_RejectsDuplicateIDs(t *testing.T) {
+	root := setupRoot(t)
+	c := testCategory("alpha", "alpha")
+	if err := Generate(root, c); err == nil {
+		t.Fatal("expected error for duplicate registry ids")
+	}
+}
+
+func TestGenerate_RejectsHandEditedValueName(t *testing.T) {
+	root := setupRoot(t)
+	c := testCategory("alpha")
+	if err := Generate(root, c); err != nil {
+		t.Fatal(err)
+	}
+
+	// Hand-corrupt the generated file: rename the value but keep the id comment.
+	path := filepath.Join(root, c.OutFile)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	corrupted := string(b)
+	corrupted = strings.Replace(corrupted, "WIDGET_ALPHA = 1", "WIDGET_RENAMED = 1", 1)
+	if err := os.WriteFile(path, []byte(corrupted), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Generate(root, c); err == nil {
+		t.Fatal("expected error parsing hand-edited generated file")
+	}
+}


### PR DESCRIPTION
## Summary

First increment of the typed-wire foundation: the protos carry rulebook content as **typed enums**, generated 1-to-1 from the toolkit registry (single source of truth). Proves the pattern on weapons + armor before the equipment `Item` rebase.

Closes #190

- `tools/refgen/` — isolated Go module (own `go.mod`/`go.sum`, depends on `rpg-toolkit`, never touches the generated SDK modules). Config-driven over `Category` entries; wired up for weapons + armor.
- `dnd5e/api/v1alpha2/weapons/weapons.proto` — enum `Weapon`, 38 values sourced from `weapons.All`.
- `dnd5e/api/v1alpha2/armor/armor.proto` — enum `Armor`, 13 values sourced from `armor.All`.
- `make refgen` — runs the tool, then `buf format -w`.

### Enum-number stability (the wire contract)
`Generate()` parses the existing `.proto` (if any), keeps every existing id→number assignment and every existing `reserved` number, assigns new ids the next free number (sorted among themselves), and turns any id that dropped out of the registry into a `reserved <n>;` line — never deleted, renumbered, or reused. First run: sorted-by-id, 1..N. **Only the number is reserved, not the name** — an enum value name is a pure function of its id, so a retired id that later reappears in the registry regenerates its old name exactly; reserving that name too would make the reappearing id collide with its own reservation and fail to compile (see "Fixed after review" below). The old name is kept only as a human-readable trailing comment on the `reserved` line. Unit tests in `tools/refgen/refgen_test.go` cover first-run numbering, idempotency, append-new-id, remove-id-becomes-reserved, the reintroduced-id-gets-a-fresh-number edge case, and — critically — two tests that run the real `buf build` against the generated output for a plain removal and for remove-then-reintroduce.

## Scope decisions
- **Registry-sourced, not consts-sourced**: ids come from `weapons.All`/`armor.All` map keys, not the `WeaponID`/`ArmorID` const blocks. This is what excludes weapons' category placeholders (`simple-weapon`, `martial-weapon`, `any-weapon`) automatically — they're choice-requirement consts, not registry entries. Armor has no such placeholders, so all 13 consts are represented.
- **Append-only reserved *numbering*, not naming**: a number is never reused even if the id that held it is later reintroduced. The old value *name* is deliberately NOT protobuf-reserved (only shown as a comment) — see "Fixed after review".
- **The generated file IS the number ledger** — there's no separate history file; `Generate()` only ever reads back the state it last wrote. Hand-editing a generated file (deleting a `reserved` line or an active value outside the tool) could let a number be reused. Mitigated by the DO-NOT-EDIT header; not otherwise enforced. Known limitation, not fixed here.
- **Weapons + armor only**: no equipment `Item` rebase in this PR — that's the next increment once this pattern is proven end to end. Abilities/features/spells follow the identical pattern later, each in its own package (per-module design: `dnd5e.weapons.Weapon` is dnd5e/PHB content only; add-on modules never get appended to this enum).
- **`refgen` not chained into `make generate`/`test`/`pre-commit`**: it resolves the toolkit Go module (network dependency, separate from `buf generate`'s remote-plugin pipeline), so it's invoked explicitly (`make refgen`) when a registry changes, not on every CI lint/format run.
- **`.gitignore`: dropped the blanket `*.sum` rule.** It predates any Go module with real external dependencies in this repo (the root `go.mod` has none) and would have silently excluded `tools/refgen/go.sum` from version control, breaking reproducible builds for the new tool. Replaced with a narrower ignore for the tool's own build binary (`/tools/refgen/refgen`).

## Fixed after review
- **C1 (uncompilable reintroduction), HIGH, fixed**: the original design reserved both the retired value's number AND name (`reserved <n>; reserved "<NAME>";`). Since a value's name is a pure function of its id, a retired id reappearing in the registry regenerates the exact same name, which collides with its own `reserved "NAME";` and fails `buf build` — reproduced locally (`value WIDGET_BETA is using a reserved name`) before fixing. Fix: reserve the number only; the old name survives as a trailing comment, not a proto reservation. New compile-check tests (`TestGenerate_RemovedID_ProtoCompiles`, `TestGenerate_RemovedThenReintroducedID_ProtoCompiles`) shell out to the real `buf build` on the generated output — the gap that let this ship green originally was that the prior tests checked parsed numbers but never verified the file actually compiled.
- **C2 (no name-uniqueness guard), fixed**: `validateCategory()` now rejects two ids that would generate the same enum value name, and an id that would collide with `<PREFIX>UNSPECIFIED` — checked up front since names are a pure function of id. Covered by `TestGenerate_RejectsCollidingGeneratedNames` and `TestGenerate_RejectsIDCollidingWithUnspecified`.
- **P2 (tolerant reserved-line parsing), fixed**: `parseExisting()`'s reserved-line parser now expands comma lists and `N to M` ranges (e.g. `reserved 2, 5 to 7;`), so a hand edit or a future buf formatting change doesn't wedge parsing. Confirmed `buf format -w` itself does NOT coalesce our one-per-line output, so this is defensive hardening rather than a correctness requirement for the tool's own idempotency loop. Covered by `TestGenerate_TolerantOfCoalescedReservedForms`.
- **P1 (ledger-is-the-file), documented only**: see the package doc comment on `tools/refgen/refgen.go` and the scope-decision bullet above. Not fixed — noted as a known limitation.
- CI: added a "Test refgen tool" step to the `generate-and-test` job (`cd tools/refgen && go test ./...`) so the compile-check tests actually run automatically; `buf` is already on PATH there via `buf-setup-action`.

## Load-bearing digest
- **Contract**: enum numbers are a wire contract — append-only, never renumbered, never reused. Enforced by `Generate()` in `tools/refgen/refgen.go`; see the "Non-negotiable" section of #190.
- **Regenerate**: `make refgen` (runs `cd tools/refgen && go run .`, then `buf format -w`). Safe to run anytime a registry changes — idempotent when nothing changed.
- **Source of truth**: `weapons.All` / `armor.All` in `rpg-toolkit/rulebooks/dnd5e/{weapons,armor}` (pinned at `rulebooks/dnd5e v0.66.0` in `tools/refgen/go.mod`), never the raw ID consts.
- **Adding a new category**: add a `Category` + id-source function in `tools/refgen/main.go`, following `weaponsCategory()`/`armorCategory()`.

## Verification
- `tools/refgen` unit tests (`go test ./...`): all 13 pass, including idempotency, the reintroduced-id edge case, name-collision rejection, and the two `buf build` compile-check tests. (TDD caught two real bugs before merge: first-run numbering started at 0 instead of 1; and the C1 reserved-name collision above.)
- Generated `weapons.proto` enum body (names + numbers) diffed against the acceptance oracle: **exact match** — `WEAPON_UNSPECIFIED = 0`, 38 values numbered 1–38 sorted by id, correct `// <id>` trailing comments. Only cosmetic column-alignment whitespace differs (confirmed `buf format -w` itself doesn't column-align, so this is the correct target shape). Re-confirmed after the C1/C2/P2 fix — output unchanged, since neither file has any retired ids yet.
- Ran `make refgen` twice in a row (tool + `buf format -w`) after the fix: zero diff on both files — confirmed idempotent.
- `buf build` passes on the remove-then-reintroduce scenario (via the new compile-check tests) — the case that failed before the fix.
- Armor enum: 13 values, no placeholders (armor has none to exclude).
- `buf lint`, `buf format --diff --exit-code`, `buf breaking --against '.git#branch=origin/main'`: all clean.
- Go SDK: verified locally via local `protoc-gen-go`/`protoc-gen-go-grpc` plugins (the repo's real `buf generate` uses `buf.build` remote plugins, which this sandbox couldn't reach) — generates and `go build`/`go vet` clean for both new packages.
- TS SDK: verified locally via `@bufbuild/protoc-gen-es` + the repo's actual `tsconfig.json` settings (`skipLibCheck: true` matters here) — `tsc --noEmit` clean for both generated files.
- CI's actual `buf generate` (authenticated remote-plugin pipeline) will run on this PR; local verification used equivalent local plugins since this sandbox lacks buf.build registry credentials.

## Test plan
- [ ] CI green (lint, format, breaking, generate, Go/TS compile)
- [ ] Reviewer confirms enum-number stability approach before this pattern is reused for future categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHGGBCWA47czyYBHy6UTuG
