### PR TITLE
feat(v1alpha2/encounter): additive WALL_KIND_DOOR_LOCKED

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ Thumbs.db
 
 # Buf
 .buf/.claude/
+
+# Worktrees (isolated agent workspaces)
+.worktrees/

--- a/dnd5e/api/v1alpha2/encounter/types.proto
+++ b/dnd5e/api/v1alpha2/encounter/types.proto
@@ -85,6 +85,9 @@ enum WallKind {
   WALL_KIND_DOOR_CLOSED = 2;
   WALL_KIND_DOOR_OPEN = 3;
   WALL_KIND_WINDOW = 4;
+  // A closed door that requires unlocking before it can be opened. Distinct from
+  // DOOR_CLOSED so the client can render locked-ness instead of discovering it on click.
+  WALL_KIND_DOOR_LOCKED = 5;
 }
 
 // TrapState is carried on TrapData entities so visible state matches what the player


### PR DESCRIPTION
## Summary

Adds the additive `WALL_KIND_DOOR_LOCKED = 5` value to the v1alpha2 `WallKind` enum
(`dnd5e/api/v1alpha2/encounter/types.proto`), so the client can render a locked door
distinctly instead of discovering it's locked only after clicking and receiving
`InputRequired{skill_check}`.

Closes #194.

## Compatibility

**Purely additive / non-breaking.** Existing values are unchanged:

```
WALL_KIND_UNSPECIFIED = 0
WALL_KIND_SOLID        = 1
WALL_KIND_DOOR_CLOSED  = 2
WALL_KIND_DOOR_OPEN    = 3
WALL_KIND_WINDOW       = 4
WALL_KIND_DOOR_LOCKED  = 5   <- new
```

Numeric assignment: `5` is the next available tag after inspecting the current
source (0-4 already in use); no gaps or reserved tags to reuse.

Also includes an unrelated one-line housekeeping commit (`.gitignore`: ignore
`.worktrees/`) needed to stand up this branch's isolated agent worktree,
matching the existing convention already in `rpg-api` and `rpg-dnd5e-web`.

## TDD exception

Per explicit approval, no source-text test was manufactured for this one
additive enum value. Verification is via `buf format`, `buf lint`,
`buf breaking`, and generation/mock checks (below).

## Verification evidence

Baseline (clean checkout of `origin/main`, before editing):
- `buf lint` → exit 0
- `buf format --diff --exit-code` → exit 0
- `buf breaking --against ".../rpg-api-protos.git#branch=main"` → exit 0
- `buf generate` → exit 0

After the change:
- `buf format -w` → diff limited to `.gitignore` (+3) and
  `dnd5e/api/v1alpha2/encounter/types.proto` (+3, the new enum value + comment);
  no unintended formatting churn.
- `buf lint` → exit 0
- `buf format --diff --exit-code` → exit 0
- `buf breaking --against ".../rpg-api-protos.git#branch=main"` → exit 0 (confirms
  additive, non-breaking)
- `buf generate` → exit 0; confirmed `WallKind_WALL_KIND_DOOR_LOCKED WallKind = 5`
  in generated Go and `WALL_KIND_DOOR_LOCKED = 5` in generated TS
- `make mocks` → exit 0

## Out of scope

Trapped/hidden/barred door states — not modelled anywhere yet (per issue).
No Space.theme/Zone.archetype work (#193) touched.

— platform agent, on behalf of KirkDiggler
