### PR TITLE
feat(v1alpha2/encounter): additive region identity — Zone.archetype + Space.theme

### DIFF
--- a/dnd5e/api/v1alpha2/encounter/types.proto
+++ b/dnd5e/api/v1alpha2/encounter/types.proto
@@ -168,12 +168,16 @@ message Wall {
 message Zone {
   string id = 1;
   string name = 2;
-  // archetype is the generator-defined room function this zone plays in the dungeon layout
-  // (e.g. "entrance", "chamber", "corridor", "boss"). Open vocabulary, not an enum — the
-  // generator's archetype set can grow without a proto release. "" means the generator did
-  // not tag this zone with a function; consumers fall back to undifferentiated handling
-  // (no archetype-specific dressing or behavior). Distinct from Space.theme: archetype is
-  // per-zone role, theme is the dungeon-wide visual family.
+  // archetype identifies this zone's room function from the toolkit's fixed, reusable
+  // vocabulary (rpg-toolkit RegionArchetype: "entrance", "chamber", "corridor", "boss" —
+  // rpg-toolkit#814) — NOT a per-generator or per-theme ad hoc value. The vocabulary may
+  // grow additively through the toolkit contract over time, but individual generators
+  // select from that shared set rather than inventing their own values. String, not an
+  // enum, because the toolkit — not this proto — owns and versions the vocabulary. ""
+  // means the generator did not tag this zone with an archetype; consumers fall back to
+  // undifferentiated handling (no archetype-specific dressing or behavior). Distinct from
+  // Space.theme: archetype is per-zone role drawn from the fixed vocabulary, theme is the
+  // dungeon-wide opaque visual family with no fixed vocabulary at all.
   string archetype = 3;
   // Future ambient hooks (lighting profile ref, music cue ref, trigger refs) will be
   // added with new field numbers as needed.

--- a/dnd5e/api/v1alpha2/encounter/types.proto
+++ b/dnd5e/api/v1alpha2/encounter/types.proto
@@ -207,8 +207,9 @@ message Space {
   // theme is the dungeon-wide visual dressing family (e.g. "crypt"), carried once at the
   // Space level — opaque to this contract, not an enum; the asset/dressing layer owns the
   // vocabulary. Distinct from Zone.archetype: theme is one visual family for the whole
-  // encounter, archetype is per-zone generator-defined room function. "" means the
-  // generator did not tag a theme; consumers fall back to default/no dressing.
+  // encounter, archetype is per-zone room function drawn from the toolkit's fixed, shared
+  // vocabulary. "" means the generator did not tag a theme; consumers fall back to
+  // default/no dressing.
   string theme = 5;
 }
 

--- a/dnd5e/api/v1alpha2/encounter/types.proto
+++ b/dnd5e/api/v1alpha2/encounter/types.proto
@@ -168,6 +168,13 @@ message Wall {
 message Zone {
   string id = 1;
   string name = 2;
+  // archetype is the generator-defined room function this zone plays in the dungeon layout
+  // (e.g. "entrance", "chamber", "corridor", "boss"). Open vocabulary, not an enum — the
+  // generator's archetype set can grow without a proto release. "" means the generator did
+  // not tag this zone with a function; consumers fall back to undifferentiated handling
+  // (no archetype-specific dressing or behavior). Distinct from Space.theme: archetype is
+  // per-zone role, theme is the dungeon-wide visual family.
+  string archetype = 3;
   // Future ambient hooks (lighting profile ref, music cue ref, trigger refs) will be
   // added with new field numbers as needed.
 }
@@ -182,7 +189,8 @@ message StatusEffect {
 }
 
 // Space is the player's current view of the world.
-// Continuous flat hex map — no rooms on the wire. Zones are optional metadata regions.
+// Continuous flat hex map — no rooms on the wire. Zones and theme are optional metadata;
+// neither structures the map for movement or rendering.
 // Visibility:
 //   - hexes and walls are sticky (explored geometry persists per character across the
 //     campaign)
@@ -192,6 +200,12 @@ message Space {
   repeated Wall walls = 2; // explored
   repeated Entity entities = 3; // currently visible (LOS-filtered)
   repeated Zone zones = 4; // optional metadata
+  // theme is the dungeon-wide visual dressing family (e.g. "crypt"), carried once at the
+  // Space level — opaque to this contract, not an enum; the asset/dressing layer owns the
+  // vocabulary. Distinct from Zone.archetype: theme is one visual family for the whole
+  // encounter, archetype is per-zone generator-defined room function. "" means the
+  // generator did not tag a theme; consumers fall back to default/no dressing.
+  string theme = 5;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Additive region-identity fields for `dnd5e.api.v1alpha2.encounter`, per #193: a client can now tell which room a hex belongs to (via existing `Hex.zone_id` + `Space.zones`), what kind of room it is (new `Zone.archetype`), and the dungeon's dressing family (new `Space.theme`).

Regions stay metadata-only, per the issue's decision: the map is still flat-hex for movement and rendering. No room structure, connections, or room-local coordinates are introduced.

## Exact contract change

`dnd5e/api/v1alpha2/encounter/types.proto`:

```proto
message Zone {
  string id = 1;
  string name = 2;
  string archetype = 3;  // NEW — additive
}

message Space {
  repeated Hex hexes = 1;
  repeated Wall walls = 2;
  repeated Entity entities = 3;
  repeated Zone zones = 4;
  string theme = 5;  // NEW — additive
}
```

| Field | Number | Type | Message |
|---|---|---|---|
| `archetype` | 3 | `string` | `Zone` (next free tag after `id=1`, `name=2`) |
| `theme` | 5 | `string` | `Space` (next free tag after `hexes=1`..`zones=4`) |

No existing field numbers, names, or types changed. `Hex.zone_id`, `Zone.id`/`Zone.name`, and `Space.hexes`/`walls`/`entities`/`zones` are untouched.

## Semantics (matches issue's approved Slice 3 correction)

- **`Zone.archetype`** — this zone's room function, drawn from the **toolkit's fixed, shared vocabulary** (`rpg-toolkit` `RegionArchetype`: `"entrance"`, `"chamber"`, `"corridor"`, `"boss"` — rpg-toolkit#814, `encounter/data.go:193-218`). Generators **select from** that shared set; they do not invent per-generator or per-theme values. String, not an enum, because the toolkit — not this proto — owns and versions the vocabulary (see "Why plain `string`" below). The vocabulary may grow additively through the toolkit contract over time.
- **`Space.theme`** — dungeon-wide visual dressing family (e.g. `"crypt"`), carried once at `Space` level. Opaque cosmetic metadata with **no fixed vocabulary at all** — the toolkit (`SpaceData.Theme`) explicitly never interprets it; distinct from `archetype`'s fixed-vocabulary contract.
- **Distinct on purpose**: `archetype` is per-`Zone` role; `theme` is one family for the whole encounter. Neither implies zones structure movement or rendering — both stay pure metadata, consistent with `Zone`'s existing doc ("Zones do NOT structure the map for movement or rendering").
- **Fallback contract**: `""` (the proto3 default) on either field means the generator did not tag that metadata. Consumers fall back to undifferentiated/default handling — no special-casing required, no new oneof/wrapper needed. This mirrors the existing precedent on `Hex.zone_id` (`// optional zone membership ("" if none)`).

## Why plain `string`, not `optional string` or an enum

- **Direct passthrough of the toolkit's own wire type.** In `rpg-toolkit` (`encounter/data.go`), `RegionData.Archetype` is `RegionArchetype string` — a defined string type, not a native Go enum/`int` — and `SpaceData.Theme` is a plain `string`. Both are `json:"...,omitempty"` on the toolkit's persisted `SpaceData`. The proto fields are a 1:1 passthrough of what the toolkit already produces; introducing a proto `enum` here would require rpg-api to translate toolkit strings into proto enum values with no toolkit-side enum to map from — an invented layer, not a passthrough.
- Every other v1alpha2 "open vocabulary" field (`Item.kind`, `Item.icon_key`, `Item.stat_line`, `Hex.zone_id`) uses a bare `string` with an `""`-means-absent comment convention rather than `optional string` — presence via wrapper isn't needed because empty string is never a valid archetype/theme value.
- An enum was considered per the issue's literal `entrance | chamber | corridor | boss` phrasing, but two things argue against it: (1) the toolkit itself deliberately didn't use a Go enum/`int` for `RegionArchetype` — it's a defined `string` type specifically so the **toolkit-owned** vocabulary can grow additively without a breaking toolkit release; a proto enum would fight that choice instead of passing it through; (2) `docs/architecture/components/shared-types.md` independently flags enum-value lifecycle as a real cost in this repo (no clean deprecation path for enum values).
- **Important nuance surfaced in review**: `string` here does **not** mean "open, generator-invented vocabulary" the way `Item.kind` is. `Zone.archetype`'s values are constrained to the toolkit's fixed `RegionArchetype` constants (`ArchetypeEntrance`/`ArchetypeChamber`/`ArchetypeCorridor`/`ArchetypeBoss`); a generator selects one of those, it doesn't define new ones. `Space.theme` has no such constraint — it's genuinely free-form cosmetic text. Both `Zone.archetype`'s own doc comment and its `Space.theme`-side cross-reference were reworded to state this fixed-vocabulary contract explicitly (commits `08575d6`, `32d5269`) and avoid "generator-defined"/"open vocabulary" phrasing that read as ad hoc per-generator values.

## Verification

Run from `dnd5e-api-protos` root (worktree `.worktrees/feat-193-region-theme-contract`):

```bash
buf format -w                                                                          # clean — no diff beyond the intentional 2 fields (verified via git diff --stat)
buf lint                                                                                # exit 0
buf breaking --against "https://github.com/KirkDiggler/rpg-api-protos.git#branch=main" # exit 0 (purely additive)
buf generate                                                                            # exit 0 — gen/go, gen/ts written
make mocks                                                                              # exit 0
```

**Generated Go** (`gen/go/dnd5e/api/v1alpha2/encounter/types.pb.go`):
```go
Archetype string `protobuf:"bytes,3,opt,name=archetype,proto3" json:"archetype,omitempty"`
Theme     string `protobuf:"bytes,5,opt,name=theme,proto3" json:"theme,omitempty"`
```
Copied `gen/go` into a scratch module (own `go.mod`, network deps resolved via `go mod tidy`) and ran:
```bash
go build ./...                                     # exit 0, whole gen/go tree
go vet ./dnd5e/api/v1alpha2/encounter/...           # exit 0
```
Wrote a throwaway program exercising both fields end to end:
```go
z := &encounterpb.Zone{Id: "z1", Name: "Antechamber"}           // archetype unset
sp := &encounterpb.Space{Zones: []*encounterpb.Zone{z}}
// z.GetArchetype() == "", sp.GetTheme() == ""                  — fallback confirmed

z2 := &encounterpb.Zone{Id: "z2", Name: "Burial Chamber", Archetype: "boss"}
sp2 := &encounterpb.Space{Zones: []*encounterpb.Zone{z, z2}, Theme: "crypt"}
wire, _ := proto.Marshal(sp2)
got := &encounterpb.Space{}
proto.Unmarshal(wire, got)
// got.GetTheme() == "crypt"
// got.Zones[0].GetArchetype() == ""      (untagged zone still falls back)
// got.Zones[1].GetArchetype() == "boss"  (tagged zone round-trips)
```
Output: `OK: additive fields, empty-string fallback semantics, and wire round-trip all verified`.

**Generated TypeScript** (`gen/ts/dnd5e/api/v1alpha2/encounter/types_pb.ts`):
```ts
/** @generated from field: string archetype = 3; */
archetype: string;
...
/** @generated from field: string theme = 5; */
theme: string;
```
```bash
npm ci
npx tsc --noEmit --project tsconfig.json           # exit 0
```

No `gen/` output is committed (gitignored, CI-regenerated per repo convention).

## Review updates (commits `08575d6`, `32d5269`)

Independent review flagged an ambiguity: the original `Zone.archetype` doc comment said "generator-defined room function" / "open vocabulary," which read as though each generator could invent its own archetype strings. That's not the contract — `rpg-toolkit`'s `RegionArchetype` is an explicit fixed, reusable vocabulary (`encounter/data.go:193-218`, rpg-toolkit#814): `"entrance"`, `"chamber"`, `"corridor"`, `"boss"`. Generators select from that shared set; they don't define their own.

- **`08575d6`** reworded `Zone.archetype`'s own doc comment to state the toolkit-owned fixed-vocabulary contract explicitly.
- **`32d5269`** fixed the same stale "generator-defined room function" phrase where it recurred in `Space.theme`'s Distinct-from-`Zone.archetype` cross-reference — missed in the first pass.

No source change in either commit: still plain `string`, still fields `3`/`5`, still `""` == untagged/fallback. `Space.theme` itself is untouched — it genuinely has no fixed vocabulary (see "Why plain `string`" above).

Re-ran the full check suite after each comment change — all clean (`buf format -w`/`lint`/`breaking --against main`/`generate` + `make mocks`, generated Go build+vet, generated TS `tsc --noEmit` — the corrected wording is embedded in both the regenerated Go doc comments and TS JSDoc).

## Consumer fallback contract

- **rpg-api projection** (`internal/handlers/dnd5e/v2/encounter/project.go`): once it populates `Hex.zone_id`/`Space.zones` from `SpaceData.Regions` (tracked separately — out of scope here per issue), it may optionally set `archetype`/`theme` from region/generator metadata. Omitting them (leaving `""`) is always valid — existing behavior is unaffected.
- **rpg-dnd5e-web**: reads `zone.archetype` / `space.theme` as plain strings; `""` means "no archetype-specific dressing" / "no theme dressing" — render the undifferentiated/default look. No new required handling, no schema migration.

## Out of scope (per issue)

- Populating `Hex.zone_id`/`Space.zones` from `SpaceData.Regions` in rpg-api (separate projection-layer issue).
- Room connections, cross-room RPCs, room-local coordinates — deliberately absent from v1alpha2.
- No enum changes (#194/#195 already merged and untouched), no obstacle contract changes (#692 unaffected), no service/RPC changes.

Closes #193.

— platform agent, on behalf of KirkDiggler

