### PR TITLE
feat(v1alpha2/encounter)!: hex knowledge event contract (#197)

### DIFF
--- a/dnd5e/api/v1alpha2/encounter/events.proto
+++ b/dnd5e/api/v1alpha2/encounter/events.proto
@@ -23,17 +23,22 @@ message EncounterEvent {
   // caused all share the same correlation_id, so the toolkit-owned combat log can be
   // reassembled from the stream. Opaque runtime id the toolkit stamps per action, so
   // it's a string (not a Ref). Empty for events with no causing action (snapshot,
-  // geometry reveal, etc.).
+  // ambient knowledge change, etc.).
   string correlation_id = 3;
+
+  // Retired with the fog-of-war contract (protos#197). GeometryRevealed was additive and
+  // sticky, so it could not express a visible/remembered partition; the two entity
+  // presence events are now statements a hex record makes. HexKnowledgeChanged at 13
+  // replaces all three.
+  reserved 10, 11, 12;
+  reserved "geometry_revealed", "entity_appeared", "entity_disappeared";
 
   oneof event {
     // Lifecycle
     SnapshotDelivered snapshot_delivered = 5;
 
-    // Geometry & visibility
-    GeometryRevealed geometry_revealed = 10;
-    EntityAppeared entity_appeared = 11;
-    EntityDisappeared entity_disappeared = 12;
+    // Knowledge & visibility
+    HexKnowledgeChanged hex_knowledge_changed = 13;
 
     // Entity state
     EntityMoved entity_moved = 20;
@@ -106,28 +111,32 @@ message SnapshotDelivered {
   Encounter encounter = 1;
 }
 
-// GeometryRevealed adds hexes/walls to the player's sticky map. Emitted when a door opens,
-// when the player moves into a previously-unseen area, or when a Reveal effect is cast.
-message GeometryRevealed {
-  repeated Hex hexes = 1;
-  repeated Wall walls = 2;
-}
-
-message EntityAppeared {
-  Entity entity = 1; // came into LOS
-  string reason = 2; // optional: "entered LOS", "spell reveal", "perception success"
-}
-
-message EntityDisappeared {
-  string entity_id = 1;
-  string reason = 2; // "left LOS", "invisibility cast"
-  // Per-viewer last-known position. Different viewers may have last seen the
-  // entity at different hexes (pass-through movement past two viewers in
-  // different positions), so the wire form is per-stream — the encounter
-  // server populates this for the specific subscriber receiving the event.
-  // Required for rendering "freeze marker at last-seen hex" without
-  // client-side game-state tracking.
-  Position last_known_position = 3;
+// HexKnowledgeChanged carries one viewer's slice of what changed about what they know.
+// It is the only event that moves fog of war, and it replaces the retired
+// GeometryRevealed / EntityAppeared / EntityDisappeared trio (protos#197).
+//
+// Hexes say WHERE; entities say WHAT. They travel in one message so a placement can
+// always resolve or fail closed — a client must never be asked to render an occupant it
+// has not been told the identity of.
+//
+// This event is a DIFF, and the absence of a record is meaningful: it means the viewer
+// learned nothing about that hex, so their existing knowledge stands untouched. A hidden
+// mutation — the world changing where this viewer cannot see — is therefore an empty
+// event or no event, never a special message. Applying it must change nothing at all.
+//
+// The client's entire behavior on receipt is: merge entities by id, then replace each
+// record by position. No freezing, no deriving, no line of sight. Everything else in
+// this contract exists to make that one sentence sufficient — see HexRecord for why a
+// visible record is total and why nothing is ever deleted.
+message HexKnowledgeChanged {
+  // Records to replace wholesale by position. Never a field-level merge: a record is a
+  // complete observation, and merging would resurrect contents the new observation
+  // deliberately omits.
+  repeated HexRecord hexes = 1;
+  // Authorized disclosure, this viewer only. Entities the viewer already knows may be
+  // resent (identity is stable, details may change); they are never un-sent, because the
+  // vocabulary must outlive visibility for remembered placements to still resolve.
+  repeated Entity entities = 2;
 }
 
 message EntityMoved {
@@ -299,13 +308,16 @@ message AttackResolved {
   repeated Ref disadvantage_sources = 11;
 }
 
+// DoorOpened is a pure notification — the beat for sound, animation and narration.
+// It carries no geometry (protos#197). A door opening changes what the viewer can see,
+// and what a viewer can see is stated by hex records; the newly-visible cells arrive as
+// a correlated HexKnowledgeChanged. Carrying reveal payloads here would have made the
+// door a second, competing source of map truth that only some viewers receive.
 message DoorOpened {
+  reserved 2, 3, 4;
+  reserved "revealed_hexes", "revealed_walls", "removed_walls";
+
   string door_entity_id = 1;
-  repeated Hex revealed_hexes = 2; // full hex (terrain + zone) for newly-visible cells
-  repeated Wall revealed_walls = 3;
-  repeated Wall removed_walls = 4; // walls no longer present (door itself transitions
-  // via DOOR_CLOSED → DOOR_OPEN; this is for any
-  // genuinely-removed barriers from the open action)
 }
 
 message DoorClosed {

--- a/dnd5e/api/v1alpha2/encounter/types.proto
+++ b/dnd5e/api/v1alpha2/encounter/types.proto
@@ -90,6 +90,25 @@ enum WallKind {
   WALL_KIND_DOOR_LOCKED = 5;
 }
 
+// HexState is what a viewer knows about one hex. Fog of war is expressed here and
+// nowhere else: knowledge is a property of the hex, not a separate overlay.
+//
+// UNSEEN is deliberately absent. A hex the viewer has never observed produces no
+// HexRecord at all — omission IS the third state, so it can never drift out of sync
+// with a value someone forgot to set. UNSPECIFIED means the producer failed to set a
+// state; treat it as a defect, not as unseen.
+//
+// There is likewise no removal/gone value. See HexRecord for why deletion does not
+// exist in this contract.
+enum HexState {
+  HEX_STATE_UNSPECIFIED = 0;
+  // Current authorized truth: the viewer observes this hex right now.
+  HEX_STATE_VISIBLE = 1;
+  // A frozen last observation, carried in full. What the viewer saw, not what is
+  // there now.
+  HEX_STATE_REMEMBERED = 2;
+}
+
 // TrapState is carried on TrapData entities so visible state matches what the player
 // should see.
 enum TrapState {
@@ -141,12 +160,57 @@ enum TargetKind {
 // Space — flat hex map with optional zones
 // =============================================================================
 
-// Hex is one cell of the player's view of the map.
-// Sticky once revealed: stays in Space.hexes for the rest of the campaign for that character.
-message Hex {
+// Placement is a thing occupying a hex, as observed. It names the occupant and how it
+// was oriented; the hex that carries it says where.
+//
+// entity_id resolves against the viewer's known entity set — entities disclosed in the
+// same message OR in an earlier one, because the entity vocabulary outlives current
+// disclosure (a remembered occupant still needs something to render as). A placement
+// that resolves against nothing MUST be dropped, never rendered as a placeholder: fail
+// closed. That is what keeps an undisclosed trap invisible to the viewer who failed the
+// perception check.
+//
+// facing rides HERE and not on Entity, and that placement is load-bearing. A record is
+// one viewer's observation: a viewer who saw a skeleton facing north and then lost sight
+// must keep facing north after the skeleton turns and a different viewer sees it face
+// south. On Entity, one viewer's sighting would rewrite every other viewer's memory.
+message Placement {
+  string entity_id = 1;
+  uint32 facing = 2; // hex-direction index 0-5
+}
+
+// HexRecord is one hex's complete authorized truth for one viewer, as observed at one
+// moment. It is the unit of truth in this contract: the client merges records by
+// position and renders what it holds. There is no separate visibility overlay, no
+// geometry list to re-associate, and no client-side line of sight.
+//
+// A VISIBLE record is TOTAL. `contents: []` is a positive claim that the hex is empty —
+// never "contents omitted". That totality is what lets a remembered occupant disappear
+// on re-sight with no forget message: the arriving record simply does not list it.
+// A producer that omits contents it cannot be bothered to compute is stating something
+// false, and the viewer will believe it.
+//
+// A REMEMBERED record carries its frozen observation IN FULL, rather than telling the
+// client to freeze what it already holds. The client therefore has exactly one behavior
+// — replace the entry for this position — and reconnect hydration is the same code path
+// as a live transition rather than a parallel one that can disagree.
+//
+// Records are idempotent: applying the same record twice leaves state identical.
+//
+// NOTHING IS EVER DELETED. There is no removal record and no tombstone. A witnessed
+// removal is a VISIBLE record that no longer lists the thing; a hidden removal is no
+// record at all. Deletion is the single operation a later observation cannot correct,
+// so this contract does not offer it.
+message HexRecord {
   Position position = 1;
-  TerrainType terrain = 2;
-  string zone_id = 3; // optional zone membership ("" if none)
+  HexState state = 2;
+  TerrainType terrain = 3;
+  string zone_id = 4; // optional zone membership ("" if none)
+  // Walls and doors on this hex's edges. Self-contained on purpose: the client never
+  // re-associates a global wall list with hexes, so remembered geometry can be drawn
+  // from the record alone.
+  repeated Wall edges = 5;
+  repeated Placement contents = 6;
 }
 
 // Wall is a barrier between two adjacent hexes.
@@ -192,17 +256,28 @@ message StatusEffect {
   optional int32 duration_rounds = 4;
 }
 
-// Space is the player's current view of the world.
+// Space is one viewer's knowledge of the world.
 // Continuous flat hex map — no rooms on the wire. Zones and theme are optional metadata;
 // neither structures the map for movement or rendering.
-// Visibility:
-//   - hexes and walls are sticky (explored geometry persists per character across the
-//     campaign)
-//   - entities are real-time LOS (server filters per player per event)
+//
+// Visibility lives entirely in the hex records. This message previously ran two
+// visibility models side by side — sticky geometry plus real-time-LOS entities — which
+// left no wire state between "explored" and "gone" and drew remembered geometry as
+// though it were currently observed. Fog of war was not renderable from it. Now a
+// snapshot is simply the viewer's accumulated records, so hydrating a reconnecting
+// client and applying a live HexKnowledgeChanged are the same operation on the same
+// shape.
 message Space {
-  repeated Hex hexes = 1; // explored, sticky
-  repeated Wall walls = 2; // explored
-  repeated Entity entities = 3; // currently visible (LOS-filtered)
+  reserved 2;
+  reserved "walls";
+
+  // This viewer's knowledge: VISIBLE and REMEMBERED records. Hexes the viewer has never
+  // observed are absent — omission is how UNSEEN is expressed.
+  repeated HexRecord hexes = 1;
+  // Authorized disclosure for this viewer: what each entity IS. Where each entity is
+  // comes from the records' contents, never from here. This is the vocabulary a
+  // remembered placement resolves against, so an entry outlives the entity's visibility.
+  repeated Entity entities = 3;
   repeated Zone zones = 4; // optional metadata
   // theme is the dungeon-wide visual dressing family (e.g. "crypt"), carried once at the
   // Space level — opaque to this contract, not an enum; the asset/dressing layer owns the
@@ -217,14 +292,25 @@ message Space {
 // Entity — common shape + typed data oneof
 // =============================================================================
 
-// Entity is anything that can occupy a position in the space.
-// Common shape (id, position, type, display_name, optional hp, armor_class,
-// status_effects) is what every entity carries because every entity is
-// destructible-or-not and has-or-doesn't-have visible statuses.
-// The oneof carries the type-specific rich data.
+// Entity is what a thing IS, as disclosed to one viewer. It is deliberately not where
+// that thing is: position was removed because HexRecord.contents is the only statement
+// of placement in this contract, and a second copy could only ever agree redundantly or
+// disagree dangerously. A viewer holding a remembered skeleton at one hex while the
+// server discloses the live skeleton elsewhere needs those to be different facts, not
+// one field fighting itself.
+//
+// Common shape (id, type, display_name, optional hp, armor_class, status_effects) is
+// what every entity carries because every entity is destructible-or-not and
+// has-or-doesn't-have visible statuses. The oneof carries the type-specific rich data.
+//
+// Every field here is authorized disclosure — a server decision, never client policy.
+// Withheld information is simply absent, and a viewer who failed a perception check
+// receives no Entity for the trap at all (and therefore no placement that resolves).
 message Entity {
+  reserved 2;
+  reserved "position";
+
   string id = 1; // runtime instance id; not a Ref
-  Position position = 2;
   EntityType type = 3;
   string display_name = 4;
   optional HitPoints hp = 5; // present only on destructibles


### PR DESCRIPTION
Closes #197. Wave A3 of KirkDiggler/rpg-project#147.

Encodes the viewer-scoped fog-of-war contract **proven by playing it** in rpg-dnd5e-web#611. This is transcription, not invention — where the issue and the concept's `events.ts` disagreed, the concept won, because it is the thing that ran.

The contract in one line: **the hex is the unit of truth, a VISIBLE record is total, and nothing is ever deleted.**

## What landed

**Added**

| Symbol | Why it has this shape |
|---|---|
| `HexState {UNSPECIFIED, VISIBLE, REMEMBERED}` | `UNSEEN` is **omission**, never a value — so it cannot drift out of sync with a field someone forgot to set. |
| `Placement {entity_id, facing}` | `facing` rides the **placement**, not the entity. Two viewers who saw the same creature face different ways must keep different memories; on `Entity`, one viewer's sighting would rewrite every other viewer's. |
| `HexRecord` (replaces `Hex`) | Knowledge is a **property of the hex**, not an overlay beside it. `edges` ride the record, so remembered geometry is drawable from the record alone with no global wall list to re-associate. |
| `HexKnowledgeChanged {hexes, entities}` | The only event that moves fog. Hexes say **where**, entities say **what**, travelling together so a placement can always resolve or fail closed. |

**Retired** — removed with tags *and* names reserved, replicating the PR #136 pattern from `docs/how-to/breaking-change-workflow.md`:

- `GeometryRevealed` — additive and sticky, so it could not express a visible/remembered partition. That is the entire feature.
- `EntityAppeared` / `EntityDisappeared` — presence and absence are now statements a hex record makes. `last_known_position` is retired with them: the record *is* the last-seen position.
- `DoorOpened.revealed_hexes` / `revealed_walls` / `removed_walls` — a door opening is new hex records arriving. `DoorOpened` becomes a pure notification for sound and narration.
- `Space.walls` — edges ride `HexRecord`.
- `Entity.position` — see below.

`EntityMoved` stays: it describes *how something travelled*, which is presentation, not knowledge.

## Two seams the issue did not settle

Both follow from the issue's own "Why `Space` cannot stay as-is" section, but neither was in its acceptance list, so calling them out explicitly:

**1. `Space.hexes` became `repeated HexRecord`.** The design says a remembered record carries its observation in full *so that live transitions and reconnect hydration are the same code path*. Leaving the snapshot as sticky `Hex` + `Wall` would have made hydration a **second, parallel path that can disagree** — the exact thing the design rules out. Now a snapshot is just the viewer's accumulated records.

**2. `Entity.position` was removed.** Once `HexRecord.contents` states placement, a position on the entity is a second source of truth that can only agree redundantly or disagree dangerously — a viewer holding a remembered skeleton at one hex while the server discloses the live one elsewhere needs those to be *different facts*, not one field fighting itself. Checked before removing: `Entity` appears as a field in exactly two places, `EntityAppeared.entity` (retired here) and `Space.entities` (now the disclosed-entity vocabulary). It had no surviving consumer.

If either reads as overreach, say so — trimming back is a small edit, but I think shipping the first without the second leaves the contradiction in place.

## Evidence

**Acceptance criterion:** *"The generated TypeScript can express every fixture in the concept's `events.ts` without adding a field."*

Proven, not asserted. I rebuilt the concept's actual fixtures — all four `FogEntity` variants, `Placement`, the four `HexRecord` shapes the concept emits (visible-empty, visible-occupied, remembered-frozen, the zone-less doorway), every `HexKnowledgeChanged` case including the empty hidden-mutation event, and a `Space` snapshot — using **only** the generated types, then typechecked it. `tsc --strict` exit **0**.

Negative control, to confirm the check had teeth rather than silently passing: adding a `position` field to a `Placement` fails with

```
error TS2353: Object literal may only specify known properties,
and 'position' does not exist in type 'MessageInit<Placement>'.
```

That is the contract now enforced by the type system rather than by discipline. The check file was throwaway and is not committed — `tsconfig.json` includes only `gen/ts`.

`buf lint`, `buf format --diff --exit-code`, and `buf generate` (Go + TS) all pass.

## Breaking

13 breaks, every one intentional and every one reserved:

```
3 messages deleted:  GeometryRevealed, EntityAppeared, EntityDisappeared, Hex
6 oneof/DoorOpened fields deleted (10,11,12 / 2,3,4)
Space.walls deleted, Space.hexes changed type Hex -> HexRecord
Entity.position deleted
```

Backward compatibility is explicitly **not** a requirement here — nothing is playable on v1alpha2 yet, and one way through beats a correct path plus a fallback. Carrying `breaking-change-approved` per `docs/how-to/breaking-change-workflow.md`.

**Known downstream fallout, expected and sequenced:** `rpg-api`'s `translate.go` populates `Entity{Id, Position}` inside `translateEntityAppearedEventWithData` — retired by this change. That is rpg-api#725/#724, the next wave.

— asset-pipeline agent, on behalf of KirkDiggler
