### PR TITLE
feat: dungeon authoring contract — dungeon_key, ListDungeons, AuthoringService

### DIFF
--- a/dnd5e/api/authoring/v1alpha1/service.proto
+++ b/dnd5e/api/authoring/v1alpha1/service.proto
@@ -12,6 +12,18 @@ option java_package = "com.kirkdiggler.rpg.api.dnd5e.authoring.v1alpha1";
 // validate_only) compilation into the live registry. key must match the
 // YAML's own declared `key:` field exactly -- mismatch is InvalidArgument
 // (design.md's Key rules).
+//
+// Error-transport decision (Opus gate finding, S0 revision 2): a
+// malformed REQUEST -- key fails the `[a-z0-9-]` charset, or key/YAML
+// `key:` mismatch -- has no meaningful response body, so it fails at the
+// transport level: gRPC InvalidArgument status, PutDungeonResponse never
+// delivered. A well-formed request whose YAML CONTENT fails
+// dungeonspec's validate/compile step returns gRPC OK with
+// PutDungeonResponse{success: false, field_errors: [...], floor_plan:
+// unset} -- this is the editor's inline-error path, and a non-OK status
+// would drop the body entirely. validate_only affects persistence only;
+// it does not change which of these two paths a given input takes. See
+// PutDungeonResponse for the success side of this contract.
 message PutDungeonRequest {
   string key = 1;
   string yaml = 2;
@@ -43,6 +55,12 @@ message FloorPlanConnector {
   int32 column = 5;
 }
 
+// FloorPlanCell is an absolute [column, row] on the compiled grid.
+message FloorPlanCell {
+  int32 column = 1;
+  int32 row = 2;
+}
+
 // FloorPlan is the compiled layout an author's board renders. door_row
 // applies uniformly to every room (dungeonspec's height/2 reserved-row
 // invariant) -- carried explicitly, not hardcoded client-side, so a
@@ -53,8 +71,27 @@ message FloorPlan {
   repeated FloorPlanConnector connectors = 2;
   int32 height = 3;
   int32 door_row = 4;
+  // entrance is the generator-chosen party spawn anchor
+  // (SpaceData.Entrance) -- the one value here a client genuinely cannot
+  // compute; it is not a function of anything else on the wire.
+  // dungeonspec.Validate does not check placements against it, so the
+  // board is the only thing that can warn an author who blocks the
+  // party's spawn cell. The party seats along a line running outward
+  // from this cell (StartEncounter), so placements near it matter.
+  // Reading archetype == "entrance" on a FloorPlanRoom identifies the
+  // entrance ROOM, not this spawn cell -- both are meaningful and
+  // distinct.
+  FloorPlanCell entrance = 5;
 }
 
+// PutDungeonResponse is only ever delivered on a gRPC OK status -- see
+// PutDungeonRequest's error-transport decision for the InvalidArgument
+// (malformed-request, no body) side of this contract. Two shapes:
+//   - success = true: floor_plan is set, field_errors is empty.
+//   - success = false: the YAML failed dungeonspec's validate/compile
+//     step; field_errors is populated (see its own comment for the v1
+//     flat-error limitation) and floor_plan is unset. This is the
+//     editor's inline-error path.
 message PutDungeonResponse {
   bool success = 1;
   // field_errors is best-effort in v1: rpg-toolkit's

--- a/dnd5e/api/authoring/v1alpha1/service.proto
+++ b/dnd5e/api/authoring/v1alpha1/service.proto
@@ -1,0 +1,74 @@
+syntax = "proto3";
+
+package dnd5e.api.authoring.v1alpha1;
+
+import "dnd5e/api/v1alpha1/common.proto";
+
+option go_package = "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/authoring/v1alpha1;authoringpb";
+option java_multiple_files = true;
+option java_package = "com.kirkdiggler.rpg.api.dnd5e.authoring.v1alpha1";
+
+// PutDungeonRequest submits a dungeonspec YAML for validation and (unless
+// validate_only) compilation into the live registry. key must match the
+// YAML's own declared `key:` field exactly -- mismatch is InvalidArgument
+// (design.md's Key rules).
+message PutDungeonRequest {
+  string key = 1;
+  string yaml = 2;
+  // validate_only compiles and returns floor_plan without persisting or
+  // mutating the registry -- the board's live per-edit preview.
+  bool validate_only = 3;
+}
+
+// FloorPlanRoom carries values a client must NEVER re-derive itself
+// (design.md's "Grid math is server-authoritative" principle):
+// start_column is the room's absolute position in the compiled
+// left-to-right chain, not something the client computes from widths + a
+// guessed connector-gap convention.
+message FloorPlanRoom {
+  string id = 1;
+  string archetype = 2; // entrance|corridor|chamber|boss (toolkit RegionArchetype)
+  int32 width = 3;
+  int32 start_column = 4;
+}
+
+// FloorPlanConnector's column is the reserved gap column BETWEEN its two
+// rooms, also server-computed -- not derived from room widths
+// client-side.
+message FloorPlanConnector {
+  string door_id = 1;
+  bool locked = 2;
+  string from_room_id = 3;
+  string to_room_id = 4;
+  int32 column = 5;
+}
+
+// FloorPlan is the compiled layout an author's board renders. door_row
+// applies uniformly to every room (dungeonspec's height/2 reserved-row
+// invariant) -- carried explicitly, not hardcoded client-side, so a
+// future toolkit change that makes it non-uniform doesn't silently break
+// the board.
+message FloorPlan {
+  repeated FloorPlanRoom rooms = 1;
+  repeated FloorPlanConnector connectors = 2;
+  int32 height = 3;
+  int32 door_row = 4;
+}
+
+message PutDungeonResponse {
+  bool success = 1;
+  // field_errors is best-effort in v1: rpg-toolkit's
+  // dungeonspec.Validate returns one flat error today, not per-field
+  // paths, so a compile failure surfaces as exactly one ValidationError
+  // (field="") wrapping that message -- not true per-cell mapping. See
+  // plan.md S1's Known v1 limitation.
+  repeated dnd5e.api.v1alpha1.ValidationError field_errors = 2;
+  FloorPlan floor_plan = 3;
+}
+
+service AuthoringService {
+  // PutDungeon is absent from the server's reflection list
+  // (Unimplemented) unless the server was started with the authoring
+  // gate enabled -- see plan.md S1.
+  rpc PutDungeon(PutDungeonRequest) returns (PutDungeonResponse);
+}

--- a/dnd5e/api/lobby/v1alpha1/service.proto
+++ b/dnd5e/api/lobby/v1alpha1/service.proto
@@ -92,6 +92,12 @@ message LeaveLobbyResponse {}
 // terminal; no lobby state survives the handoff.
 message StartEncounterRequest {
   string lobby_id = 1;
+  // dungeon_key selects which authored dungeon to build the encounter
+  // from. Empty uses the server's existing caller -> env -> default
+  // precedence (rpg-api's lobby orchestrator,
+  // StartEncounterInput.DungeonKey) -- additive, every existing caller
+  // is unaffected.
+  string dungeon_key = 2;
 }
 
 // StartEncounterResponse returns the encounter_id clients switch to. Ordering
@@ -166,6 +172,21 @@ message GetMyActiveLobbyResponse {
   LobbyStatus lobby_status = 3;
 }
 
+// ListDungeonsRequest has no fields -- ListDungeons returns every dungeon
+// key + display name the server can StartEncounter from.
+message ListDungeonsRequest {}
+
+// DungeonSummary is one authored dungeon's key + display name, as seen by
+// the lobby dropdown.
+message DungeonSummary {
+  string key = 1;
+  string name = 2;
+}
+
+message ListDungeonsResponse {
+  repeated DungeonSummary dungeons = 1;
+}
+
 // =============================================================================
 // Service
 // =============================================================================
@@ -210,4 +231,10 @@ service LobbyService {
   // no active lobby, not an error. encounter_id is only populated when the
   // lobby is STARTED and the encounter has been verified still live.
   rpc GetMyActiveLobby(GetMyActiveLobbyRequest) returns (GetMyActiveLobbyResponse);
+
+  // ListDungeons returns every dungeon key + display name the server
+  // can StartEncounter from. NOT behind the authoring gate -- reads
+  // content, mutates nothing; the lobby dropdown needs this with
+  // authoring off (design.md's post-approval correction, 2026-07-30).
+  rpc ListDungeons(ListDungeonsRequest) returns (ListDungeonsResponse);
 }

--- a/docs/architecture/components/authoring-service.md
+++ b/docs/architecture/components/authoring-service.md
@@ -1,0 +1,120 @@
+---
+name: AuthoringService
+description: Dev-gated dungeon authoring surface — PutDungeon compiles and (unless validate_only) persists a dungeonspec YAML, returning a server-computed floor plan
+updated: 2026-07-30
+confidence: high — verified by reading dnd5e/api/authoring/v1alpha1/service.proto end-to-end; no consumer yet (rpg-api S1 is the immediate next leg of the same arc)
+---
+
+# AuthoringService
+
+New service, own subpackage `dnd5e/api/authoring/v1alpha1`. Defined in
+`dnd5e/api/authoring/v1alpha1/service.proto` (~75 lines). Part of the
+Dungeon Builder arc (`rpg-project#169`, design PR `rpg-project#170`) — the
+in-game authoring loop that replaces "edit YAML, restart the server" with a
+live, server-validated preview.
+
+## Why its own service, not an RPC on LobbyService
+
+Per `docs/how-to/add-a-new-service.md`'s three-question checklist:
+content authoring doesn't fit `CharacterService`/`EncounterService`/
+`LobbyService`'s bounded contexts (does it belong on an existing service?
+no); it's a distinct aggregate from party/encounter state (does it have
+its own ownership boundary? yes); rpg-api's authoring orchestrator (S1 of
+the same arc) is its live consumer in flight, not a speculative one (will
+multiple services share it? not today, but there's a consumer already
+queued).
+
+## File and shape
+
+- `dnd5e/api/authoring/v1alpha1/service.proto` — 1 service, 1 RPC, 5
+  messages.
+- Imports `dnd5e/api/v1alpha1/common.proto` for `ValidationError` — no new
+  error type invented.
+
+## RPC
+
+| RPC | Purpose |
+|---|---|
+| `PutDungeon` | Validates + compiles a dungeonspec YAML; unless `validate_only`, persists it (write-through) and swaps it into the live registry `StartEncounter` reads |
+
+`PutDungeonRequest`:
+```proto
+string key = 1;           // must match the YAML's own declared key: field
+string yaml = 2;
+bool validate_only = 3;   // true: compile + return floor_plan, no persist
+```
+
+`PutDungeonResponse`:
+```proto
+bool success = 1;
+repeated dnd5e.api.v1alpha1.ValidationError field_errors = 2;  // v1: one flat entry per compile failure
+FloorPlan floor_plan = 3;
+```
+
+## The FloorPlan response contract
+
+The design's server-authoritative-grid-math principle (design.md,
+"Grid math is server-authoritative"): the client never re-derives
+room-chain offsets or connector-gap columns from room widths. `FloorPlan`
+carries every value a naive board implementation might otherwise
+reconstruct with arithmetic:
+
+- `FloorPlanRoom.start_column` — the room's absolute position in the
+  compiled left-to-right chain.
+- `FloorPlanConnector.column` — the reserved gap column between its two
+  rooms.
+- `FloorPlan.door_row` — applies uniformly to every room today
+  (dungeonspec's `height/2` invariant), carried explicitly so a future
+  non-uniform toolkit change doesn't silently break a board that hardcoded
+  the formula.
+
+## Error shape — a deliberate deviation from `bool success + string error`
+
+`add-a-new-service.md`'s default error pattern is `bool success = 1;
+string error = 2;` "unless you have a strong reason to design a typed
+error." This service has one: `field_errors` reuses the existing
+`dnd5e.api.v1alpha1.ValidationError` (field/message/code) rather than a
+bare string, so an editor can render errors inline per the design's UX
+requirement. **Known v1 limitation**, stated plainly here because it
+constrains what the web editor can honestly promise: `rpg-toolkit`'s
+`dungeonspec.Validate` returns one flat `error`, not per-field paths, so a
+compile failure surfaces as exactly one `ValidationError` (`field=""`)
+today — not true per-cell mapping. A future toolkit enhancement to return
+structured per-field errors is follow-up work, not part of this arc.
+
+## The authoring gate (rpg-api side, not visible in this proto)
+
+`PutDungeon` is absent from the server's reflection list
+(`Unimplemented`) unless rpg-api was started with its authoring env flag
+set — this proto carries no gate of its own; the RPC is simply not
+registered when the gate is off. See `rpg-api`'s S1 slice of the same arc.
+
+## Live consumers
+
+None yet at merge time. `rpg-api` (arc slice S1, `PutDungeon` orchestrator
++ authoring gate + shared registry) and `rpg-dnd5e-web` (arc slices S4a-c,
+the `/author` route) are both queued as the next legs of the same arc —
+this is the "no consumer in flight" anti-pattern's explicit exception, not
+a violation of it.
+
+## Design notes
+
+- **No pagination, no listing RPC here.** `ListDungeons` (key + display
+  name for the lobby dropdown) lives on `LobbyService`, deliberately not
+  gated — see `lobby-service.md`'s note or `dnd5e/api/lobby/v1alpha1/service.proto`.
+  Reads content, mutates nothing; must work with authoring off.
+- **`validate_only` over a sibling `Preview` RPC.** One RPC, one message
+  pair, a bool flag — simpler than a second RPC with a near-identical
+  request/response shape, and the flag reads naturally at the call site.
+- **Preview/dry-run compiles at a fixed default seed**, not a
+  caller-supplied one (design.md) — seed only affects rolled content,
+  which the editor keeps off-grid in its own "rolled content" panel, so
+  the live per-edit board preview doesn't need seed control. Not
+  represented as a proto field for that reason.
+
+## Confidence and what's not verified
+
+- RPC and message counts verified by reading the file directly.
+- No live consumer to verify runtime behavior against — this doc describes
+  the wire contract only, per this repo's own scope ("it never runs at
+  runtime").

--- a/docs/architecture/components/authoring-service.md
+++ b/docs/architecture/components/authoring-service.md
@@ -26,7 +26,7 @@ queued).
 
 ## File and shape
 
-- `dnd5e/api/authoring/v1alpha1/service.proto` — 1 service, 1 RPC, 5
+- `dnd5e/api/authoring/v1alpha1/service.proto` — 1 service, 1 RPC, 6
   messages.
 - Imports `dnd5e/api/v1alpha1/common.proto` for `ValidationError` — no new
   error type invented.
@@ -67,6 +67,39 @@ reconstruct with arithmetic:
   (dungeonspec's `height/2` invariant), carried explicitly so a future
   non-uniform toolkit change doesn't silently break a board that hardcoded
   the formula.
+- `FloorPlan.entrance` (`FloorPlanCell{column, row}`) — the
+  generator-chosen party spawn anchor (`SpaceData.Entrance`). Added in the
+  Opus gate's S0 revision: it's the one value in this contract a client
+  genuinely cannot compute (not a function of anything else on the wire),
+  and `dungeonspec.Validate` doesn't check placements against it — the
+  board is the only thing that can warn an author who blocks the party's
+  own spawn cell. Distinct from `FloorPlanRoom.archetype == "entrance"`,
+  which identifies the entrance *room*, not this cell.
+
+## Error transport — decided, not left to drift between S1 and S4c
+
+Opus gate finding on the first S0 revision: design.md's "returns
+structured errors (field-path-mapped, `InvalidArgument`)" describes two
+transports gRPC can't combine — a non-OK status never delivers the
+response body, so `field_errors`/`floor_plan` would be unreachable on an
+`InvalidArgument` return. Decided and documented in the proto comments
+(`PutDungeonRequest`/`PutDungeonResponse`) so S1 (produces this) and S4c
+(consumes it) can't independently guess different answers:
+
+- **Malformed request** (key fails `[a-z0-9-]`, or key/YAML `key:`
+  mismatch) — no meaningful body exists, so this is transport-level gRPC
+  `InvalidArgument`. `PutDungeonResponse` is never delivered.
+- **Well-formed request, YAML content fails dungeonspec
+  validate/compile** — gRPC `OK` with `PutDungeonResponse{success: false,
+  field_errors: [...], floor_plan: unset}`. This is the editor's inline
+  compile-error path; a non-OK status here would silently drop the one
+  message the v1 flat-error limitation already leaves an author with.
+- **Success** — `success: true`, `floor_plan` set, `field_errors` empty.
+- `validate_only` affects persistence only — it does not change which of
+  the above three paths a given input takes.
+- Gate off — `Unimplemented` (the RPC is unregistered; unaffected by any
+  of the above, and doesn't collide with the availability-probe pattern
+  S4a uses to distinguish "gate off" from "server unreachable").
 
 ## Error shape — a deliberate deviation from `bool success + string error`
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -45,9 +45,11 @@ rpg-api-protos/
   dnd5e/api/v1alpha2/armor/      # Armor enum, same pattern as weapons/ (#190)
     armor.proto
   dnd5e/api/lobby/v1alpha1/      # service-first layout; own version clock (rpg-project#80)
-    service.proto                # LobbyService — party-assembly RPCs; not yet consumed (rpg-api pending)
+    service.proto                # LobbyService — party-assembly RPCs; not yet consumed (rpg-api pending); also carries StartEncounterRequest.dungeon_key + ListDungeons (Dungeon Builder arc, rpg-project#169)
     types.proto                  # LobbyMember
     events.proto                 # LobbyEvent stream — snapshot + membership/presence deltas
+  dnd5e/api/authoring/v1alpha1/  # own subpackage; dev-gated dungeon authoring (Dungeon Builder arc, rpg-project#169)
+    service.proto                # AuthoringService — PutDungeon; not yet consumed (rpg-api S1 pending)
   sandbox/api/v1alpha1/
     sandbox_common.proto        # GenerativeRoomConfig, RoomShape, etc. — defined, not consumed
     sandbox_room.proto          # SandboxRoomService — defined, not consumed

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -172,7 +172,30 @@ documented in comments rather than invented as separate contract paths.
 reassemble — right-sized rather than copy-pasted. Held below A by: no
 runtime validation this shape survives contact with the orchestrator layer
 yet, and `character_name` enrichment / party-cap config aren't verifiable
-from the proto alone. Re-grade once the rpg-api PR lands.
+from the proto alone. Re-grade once the rpg-api PR lands. Grew a
+`dungeon_key` field on `StartEncounterRequest` and a `ListDungeons` RPC
+(rpg-api-protos#200, 2026-07-30, Dungeon Builder arc) — both additive,
+grade unchanged by this addition alone.
+
+### dnd5e.authoring.AuthoringService — B+ (provisional)
+
+Landed 2026-07-30 (rpg-api-protos#200), no consumer yet — same
+"consumer PR pending, not speculative" exception as LobbyService above:
+`rpg-api` (arc slice S1) and `rpg-dnd5e-web` (arc slices S4a-c) are both
+queued next legs of the same arc (`rpg-project#169`/`#170`), not
+schema-without-a-plan. One focused RPC (`PutDungeon`), own subpackage
+justified against the three-question checklist in
+`add-a-new-service.md` (own bounded context, live consumer queued).
+Reuses `dnd5e.api.v1alpha1.ValidationError` for `field_errors` rather
+than inventing a new error type — a deliberate, documented deviation
+from the repo's default `bool success + string error` pattern (see
+[authoring-service.md](components/authoring-service.md)). `FloorPlan`'s
+explicit `start_column`/`column`/`door_row` fields are a clean
+application of "server computes, client never re-derives." Held below A
+by: no runtime validation yet, and `field_errors` is honestly
+one-flat-entry-per-failure in v1 (documented, not hidden — the toolkit's
+`dungeonspec.Validate` doesn't return structured field paths today).
+Re-grade once the rpg-api PR lands.
 
 ## Defined-but-not-consumed services
 

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -190,9 +190,17 @@ Reuses `dnd5e.api.v1alpha1.ValidationError` for `field_errors` rather
 than inventing a new error type — a deliberate, documented deviation
 from the repo's default `bool success + string error` pattern (see
 [authoring-service.md](components/authoring-service.md)). `FloorPlan`'s
-explicit `start_column`/`column`/`door_row` fields are a clean
-application of "server computes, client never re-derives." Held below A
-by: no runtime validation yet, and `field_errors` is honestly
+explicit `start_column`/`column`/`door_row`/`entrance` fields are a clean
+application of "server computes, client never re-derives" — `entrance`
+was added in an Opus-gate revision (design.md names it as one of four
+required response elements; the initial cut had three). The gate's other
+finding on that same pass — design.md's `InvalidArgument` line being
+untransportable alongside a response body — is now a documented decision
+in the proto comments rather than an implicit assumption S1 and S4c could
+independently guess differently: transport-level `InvalidArgument` for
+malformed requests (no body exists), in-band `success=false` +
+`field_errors` for content that fails to compile. Held below A by: no
+runtime validation yet, and `field_errors` is honestly
 one-flat-entry-per-failure in v1 (documented, not hidden — the toolkit's
 `dungeonspec.Validate` doesn't return structured field paths today).
 Re-grade once the rpg-api PR lands.

--- a/docs/status.md
+++ b/docs/status.md
@@ -16,6 +16,21 @@ shape and consumer drift, it shows up here as a "rough edge."
 
 ## Active work
 
+- **Dungeon Builder: authoring contract (rpg-api-protos#200, S0 of the
+  Dungeon Builder arc, 2026-07-30)** — additive-only, one PR: `dungeon_key`
+  field on `StartEncounterRequest` (`dnd5e/api/lobby/v1alpha1/service.proto`);
+  `ListDungeons` RPC + `DungeonSummary`/`ListDungeonsResponse` on
+  `LobbyService`, deliberately ungated (reads content, mutates nothing —
+  the lobby dropdown needs it with authoring off); new `AuthoringService`
+  in its own subpackage `dnd5e/api/authoring/v1alpha1` with `PutDungeon`
+  (key/yaml/`validate_only`) returning a server-computed `FloorPlan` plus
+  best-effort `field_errors`. See
+  [architecture/components/authoring-service.md](architecture/components/authoring-service.md).
+  Proto-only — `rpg-api` (S1: `PutDungeon` orchestrator + shared registry;
+  S2: `dungeon_key` plumbing) and `rpg-dnd5e-web` (S3: lobby dropdown;
+  S4a-c: `/author` route) are both queued as the next legs of the same arc
+  (design: `rpg-project#170`, plan: `rpg-project/ideas/dungeon-builder/plan.md`).
+
 - **Typed content vocabulary, increment 1 (rpg-api-protos#190, PR #191,
   2026-07-20) + equipment on the wire (rpg-api-protos#187, PR #188,
   2026-07-21)** — #190 adds `tools/refgen` (a codegen tool, own `go.mod`,
@@ -263,6 +278,7 @@ Your read of where we are. See [quality.md](quality.md) for grade + rationale.
 | `dnd5e.EncounterService` | Medium — works in production; carries two state shapes (legacy + unified), four deprecated RPCs, and many `reserved` slots. Highest churn, biggest cleanup debt |
 | `dnd5e.CharacterService` | Medium-high — the biggest service by RPC count (~25 RPCs); coherent draft + finalize flow; deprecated proficiency fields still present |
 | `api.DiceService` | High — small (3 RPCs), consumed by rpg-api, well-shaped |
+| `dnd5e.authoring.AuthoringService` | High — new (rpg-api-protos#200, 2026-07-30), 1 focused RPC, no consumer yet but one queued in the same arc (rpg-api S1) |
 | `api.EnvironmentService` | Low — defined, not consumed. Generic room shape duplicates encounter Room |
 | `api.SpatialService` | Low — defined, not consumed |
 | `api.SpawnService` | Low — defined, not consumed |

--- a/docs/status.md
+++ b/docs/status.md
@@ -278,7 +278,7 @@ Your read of where we are. See [quality.md](quality.md) for grade + rationale.
 | `dnd5e.EncounterService` | Medium — works in production; carries two state shapes (legacy + unified), four deprecated RPCs, and many `reserved` slots. Highest churn, biggest cleanup debt |
 | `dnd5e.CharacterService` | Medium-high — the biggest service by RPC count (~25 RPCs); coherent draft + finalize flow; deprecated proficiency fields still present |
 | `api.DiceService` | High — small (3 RPCs), consumed by rpg-api, well-shaped |
-| `dnd5e.authoring.AuthoringService` | High — new (rpg-api-protos#200, 2026-07-30), 1 focused RPC, no consumer yet but one queued in the same arc (rpg-api S1) |
+| `dnd5e.authoring.AuthoringService` | High (contract) / no consumer yet — new (rpg-api-protos#200, 2026-07-30), 1 focused RPC, gate-passed for shape and error-transport clarity; a consumer (rpg-api S1) is queued in the same arc, distinct from the Low-rated services below which have none in flight |
 | `api.EnvironmentService` | Low — defined, not consumed. Generic room shape duplicates encounter Room |
 | `api.SpatialService` | Low — defined, not consumed |
 | `api.SpawnService` | Low — defined, not consumed |


### PR DESCRIPTION
## Summary

S0 of the Dungeon Builder arc — one additive PR carrying everything the rest of the arc needs, so S1/S2/S3/S4a-c (rpg-api and rpg-dnd5e-web) never block on a second protos PR.

1. **`dungeon_key` field on `StartEncounterRequest`** (`dnd5e/api/lobby/v1alpha1/service.proto`, field 2) — selects which authored dungeon to build the encounter from. Empty preserves today's caller → env → default precedence unchanged; every existing caller is unaffected.
2. **`ListDungeons` RPC on `LobbyService`** (not the new authoring service — deliberate, per design.md's post-approval correction) — returns `key` + `name` for every dungeon the server can `StartEncounter` from. Ungated: reads content, mutates nothing, so the lobby dropdown works with authoring off.
3. **New `AuthoringService`** in its own subpackage `dnd5e/api/authoring/v1alpha1` — `PutDungeon(key, yaml, validate_only)` returns a server-computed `FloorPlan`: rooms with absolute `start_column`, connectors with the reserved gap `column`, and a uniform `door_row` — every value a naive client board might otherwise reconstruct with arithmetic is instead an explicit wire value (design.md's "grid math is server-authoritative" principle). `field_errors` reuses `dnd5e.api.v1alpha1.ValidationError` rather than inventing a new error type.

**Additive only — `buf breaking` is clean against main.** No renumbering, no renames, no removals.

Design: rpg-project#170 (design PR, Kirk-approved 2026-07-30) · rpg-project#169 (design issue) · plan: `rpg-project/ideas/dungeon-builder/plan.md`, section S0. Issue: #200.

**Consumers:** `rpg-api` (S1: `PutDungeon` orchestrator + authoring gate + shared registry; S2: `dungeon_key` plumbing on `StartEncounter`) and `rpg-dnd5e-web` (S3: lobby dropdown; S4a-c: the `/author` route) both regen against this once merged — naming that explicitly since this slice blocks four others in the arc.

## Verification (all five, verbatim)

```
$ buf format -w
(no output — already formatted)

$ buf lint
(clean, exit 0)

$ buf format --diff --exit-code
(clean, exit 0)

$ buf breaking --against "https://github.com/KirkDiggler/rpg-api-protos.git#branch=main"
(clean, exit 0)

$ buf generate
(clean, exit 0)

$ ls gen/go/dnd5e/api/authoring/v1alpha1/*.pb.go
gen/go/dnd5e/api/authoring/v1alpha1/service.pb.go
gen/go/dnd5e/api/authoring/v1alpha1/service_grpc.pb.go

$ ls gen/ts/dnd5e/api/authoring/v1alpha1/*.ts
gen/ts/dnd5e/api/authoring/v1alpha1/service_pb.ts
```

## Docs updated in this PR (per `add-a-new-service.md`'s checklist)

- New `docs/architecture/components/authoring-service.md`, shape of `dice-service.md`.
- `docs/architecture/overview.md`'s repo layout block — new `dnd5e/api/authoring/v1alpha1/` entry, note added to the `lobby/` entry.
- `docs/status.md` — active-work entry + per-service confidence row.
- `docs/quality.md` — new `AuthoringService` scorecard entry (B+ provisional, same "consumer PR pending, not speculative" exception as `LobbyService`'s existing entry); noted the additive `dungeon_key`/`ListDungeons` growth on the existing `LobbyService` entry.

## Deviations from plan.md's S0 sketch

None in shape — field names, message names, RPC names, and the service split all match the plan's sketch exactly. One editorial choice: `ValidationError` import stayed scoped to `dnd5e.api.v1alpha1.common.proto` exactly as the plan specified (not the generic `api.v1alpha1.ValidationResult`), consistent with `add-a-new-service.md`'s reuse-before-redefine guidance.

## Not in this PR

Everything downstream (rpg-api orchestrator + registry + gate, rpg-dnd5e-web dropdown/editor) is S1-S4c, separate issues/PRs per plan.md. This PR does not merge anything into `main` for those repos.

— asset-pipeline agent, on behalf of KirkDiggler

Closes #200.
