### PR TITLE
feat(v1alpha1/choices): additive EquipmentCategoryChoice.options

### DIFF
--- a/dnd5e/api/v1alpha1/choices.proto
+++ b/dnd5e/api/v1alpha1/choices.proto
@@ -126,6 +126,12 @@ message EquipmentCategoryChoice {
   repeated ArmorCategory armor_categories = 3; // Armor categories to choose from
   repeated ToolCategory tool_categories = 4; // Tool categories to choose from
   string label = 5; // Description (e.g., "Choose two martial weapons")
+
+  // Concrete, eligible, enriched items this category resolves to (toolkit-computed
+  // via the same eligibility function the validator runs). Optional for backward
+  // compatibility: empty until the API populates it from the toolkit's resolution.
+  // See rpg-project#173 (ideas/equipment-enrichment/design.md).
+  repeated EquipmentItem options = 6;
 }
 
 // Languages that can be chosen


### PR DESCRIPTION
## Status: READY

## What

Adds `repeated EquipmentItem options = 6;` to `EquipmentCategoryChoice` (`dnd5e/api/v1alpha1/choices.proto`) so a category choice ("choose a martial weapon") carries its full, concrete, enriched membership on the wire.

Field number **6** is the next unused tag on the actual message — existing fields are `choose = 1`, `weapon_categories = 2`, `armor_categories = 3`, `tool_categories = 4`, `label = 5` (the issue's illustrative snippet assumed a different, hypothetical shape for the message; the real message differs, so I chose 6 against the real field list, not the issue's guess). All five existing fields are untouched — additive only.

Reuses the existing `EquipmentItem` / `equipment_detail` shape already landed for concrete grants (`EquipmentItem` message, same file) — no new message types. Empty `options` until the API populates it from the toolkit's resolution; existing consumers unaffected.

## Why

Design: rpg-project#173 (`ideas/equipment-enrichment/design.md`, 2026-08-01 update) — toolkit resolves each category choice to concrete, eligible, enriched items using the same eligibility function the validator runs; this is the contract leg that lets the API map that resolution onto the wire. Second leg of the merge order — lands after/parallel with the toolkit leg, before the API leg that consumes it.

## Gates run locally

- `buf format -w` — clean, no diff beyond the intended field
- `buf lint` — clean
- `buf breaking --against '.git#branch=main'` — clean (no breaking changes)
- `buf generate` — regenerates `gen/go` + `gen/ts` (gitignored, not committed, per repo convention — CI publishes from these on merge)
- `make mocks` — regenerated gRPC mocks, clean
- `make compile-go` — `gen/go` builds
- `make compile-ts` — `tsc --noEmit` clean
- `make test` (lint + format --diff --exit-code + generate + mocks) — clean

No schema-level proto tests exist in this repo for message shape (precedent: prior small additive-field PRs, e.g. #185, #195, carry no proto tests); none added here to match convention.

## Docs

No architecture doc references `EquipmentCategoryChoice` by name or line number today (checked `docs/architecture/components/character-service.md` and `shared-types.md`, which document `choices.proto` generally) — nothing to update. Following the precedent of prior small additive-field PRs (#185 Wall.id, #195 WALL_KIND_DOOR_LOCKED), which also touched no docs.

## Closes

Closes #202
Linked design: rpg-project#173

— asset-pipeline agent, on behalf of KirkDiggler