### PR TITLE
feat(authoring): add FloorPlan generated edge contract

### DIFF
--- a/dnd5e/api/authoring/v1alpha1/service.proto
+++ b/dnd5e/api/authoring/v1alpha1/service.proto
@@ -71,26 +71,38 @@ enum FloorPlanEdgeKind {
   FLOOR_PLAN_EDGE_KIND_DOOR = 2;
 }
 
-// FloorPlanEdge is one generated canonical wall or door edge in the compiled
-// authoring layout. `from` and `to` are the toolkit's canonical, adjacent
-// cell endpoints; `to` may be outside the rendered floor-plan bounds for an
-// exterior edge. Consumers render this one record and must not derive a
-// competing edge from adjacent rooms or cells.
+// FloorPlanEdge is one generated wall or door edge in the compiled authoring
+// layout. A physical edge is the undirected pair {from, to}: endpoints MUST
+// be distinct adjacent FloorPlanCells. FloorPlan.edges MUST emit exactly one
+// record for each physical edge. Reversing endpoints denotes the same edge,
+// so a reversed duplicate and records that conflict on kind or door_id are
+// forbidden.
+//
+// `from` and `to` are field names only; this contract defines no canonical
+// endpoint order and clients MUST NOT derive meaning from their orientation.
+// For an exterior edge, one endpoint may be outside the rendered floor-plan
+// bounds. Consumers render this one record and must not derive a competing
+// edge from adjacent rooms or cells.
 //
 // This read-only authoring projection maps to the runtime
 // HexRecord.edges representation after an encounter starts, but intentionally
 // does not import or reuse dnd5e.api.v1alpha2.encounter.Wall/WallKind:
 // runtime edges carry live encounter state, while this contract carries the
-// generator's authoring truth.
+// generator's authoring truth. To map an endpoint, convert its [column, row]
+// pointy-top offset coordinate to the runtime Position cube coordinate. The
+// resulting runtime Wall represents the same undirected pair: SOLID maps to
+// WALL_KIND_SOLID with no Wall.id; DOOR maps to a door Wall (initially
+// WALL_KIND_DOOR_CLOSED or WALL_KIND_DOOR_LOCKED) whose Wall.id is door_id,
+// and its runtime kind can later become WALL_KIND_DOOR_OPEN.
 message FloorPlanEdge {
   FloorPlanCell from = 1;
   FloorPlanCell to = 2;
   FloorPlanEdgeKind kind = 3;
-  // source_id preserves the opaque, stable identity assigned by the canonical
-  // generator when available (currently a connector door). It is unset for
-  // generated solid edges without a source identity. Consumers use it to keep
-  // a door's identity across projections; they never synthesize an id.
-  optional string source_id = 4;
+  // Required, non-empty, and unique among DOOR edges. For a generated
+  // connector door it MUST equal that FloorPlanConnector.door_id, and maps to
+  // runtime Wall.id. It MUST be absent for SOLID edges. These are producer
+  // contract rules; proto parsing alone does not validate them.
+  optional string door_id = 4;
 }
 
 // FloorPlan is the compiled layout an author's board renders. door_row

--- a/dnd5e/api/authoring/v1alpha1/service.proto
+++ b/dnd5e/api/authoring/v1alpha1/service.proto
@@ -61,6 +61,38 @@ message FloorPlanCell {
   int32 row = 2;
 }
 
+// FloorPlanEdgeKind describes the authoring meaning of a generated canonical
+// dungeon edge. It is deliberately local to FloorPlan: it is NOT runtime
+// dnd5e.api.v1alpha2.encounter.WallKind, whose values include live encounter
+// state that this read-only compiled-layout response does not carry.
+enum FloorPlanEdgeKind {
+  FLOOR_PLAN_EDGE_KIND_UNSPECIFIED = 0;
+  FLOOR_PLAN_EDGE_KIND_SOLID = 1;
+  FLOOR_PLAN_EDGE_KIND_DOOR = 2;
+}
+
+// FloorPlanEdge is one generated canonical wall or door edge in the compiled
+// authoring layout. `from` and `to` are the toolkit's canonical, adjacent
+// cell endpoints; `to` may be outside the rendered floor-plan bounds for an
+// exterior edge. Consumers render this one record and must not derive a
+// competing edge from adjacent rooms or cells.
+//
+// This read-only authoring projection maps to the runtime
+// HexRecord.edges representation after an encounter starts, but intentionally
+// does not import or reuse dnd5e.api.v1alpha2.encounter.Wall/WallKind:
+// runtime edges carry live encounter state, while this contract carries the
+// generator's authoring truth.
+message FloorPlanEdge {
+  FloorPlanCell from = 1;
+  FloorPlanCell to = 2;
+  FloorPlanEdgeKind kind = 3;
+  // source_id preserves the opaque, stable identity assigned by the canonical
+  // generator when available (currently a connector door). It is unset for
+  // generated solid edges without a source identity. Consumers use it to keep
+  // a door's identity across projections; they never synthesize an id.
+  optional string source_id = 4;
+}
+
 // FloorPlan is the compiled layout an author's board renders. door_row
 // applies uniformly to every room (dungeonspec's height/2 reserved-row
 // invariant) -- carried explicitly, not hardcoded client-side, so a
@@ -82,6 +114,10 @@ message FloorPlan {
   // entrance ROOM, not this spawn cell -- both are meaningful and
   // distinct.
   FloorPlanCell entrance = 5;
+  // Generated canonical wall and door truth for this compiled layout. This
+  // is the only edge list an authoring client renders or hit-tests; no flat
+  // runtime Space.walls field exists or may be reintroduced.
+  repeated FloorPlanEdge edges = 6;
 }
 
 // PutDungeonResponse is only ever delivered on a gRPC OK status -- see

--- a/dnd5e/api/authoring/v1alpha1/testdata/floor_plan_edges.textproto
+++ b/dnd5e/api/authoring/v1alpha1/testdata/floor_plan_edges.textproto
@@ -1,0 +1,58 @@
+# Contract fixture for FloorPlan.edges (rpg-api-protos#205).
+#
+# This is the representative generated-edge excerpt for dungeon-content/showcase.yaml:
+# three rooms (6 + 14 + 8 columns), two connector columns, height 8, and
+# door_row 4. It demonstrates the authoring projection without asking clients
+# to derive geometry: an exterior solid wall, an interior-facing solid segment,
+# and a door retaining the source identity generated for its connector.
+height: 8
+door_row: 4
+rooms: {
+  id: "antechamber"
+  archetype: "entrance"
+  width: 6
+  start_column: 0
+}
+rooms: {
+  id: "shrine"
+  archetype: "chamber"
+  width: 14
+  start_column: 7
+}
+rooms: {
+  id: "vault"
+  archetype: "boss"
+  width: 8
+  start_column: 22
+}
+connectors: {
+  door_id: "showcase-door-antechamber-shrine"
+  from_room_id: "antechamber"
+  to_room_id: "shrine"
+  column: 6
+}
+connectors: {
+  door_id: "showcase-door-shrine-vault"
+  from_room_id: "shrine"
+  to_room_id: "vault"
+  column: 21
+}
+edges: {
+  # Exterior wall: to.column -1 is outside this plan's [0, 29] floor bounds.
+  from: { column: 0 row: 0 }
+  to: { column: -1 row: 0 }
+  kind: FLOOR_PLAN_EDGE_KIND_SOLID
+}
+edges: {
+  # Interior-facing solid segment: both endpoints are in the compiled layout.
+  from: { column: 3 row: 2 }
+  to: { column: 4 row: 2 }
+  kind: FLOOR_PLAN_EDGE_KIND_SOLID
+}
+edges: {
+  # Door: source_id exactly retains the matching first connector's opaque ID.
+  from: { column: 5 row: 4 }
+  to: { column: 6 row: 4 }
+  kind: FLOOR_PLAN_EDGE_KIND_DOOR
+  source_id: "showcase-door-antechamber-shrine"
+}

--- a/dnd5e/api/authoring/v1alpha1/testdata/floor_plan_edges.textproto
+++ b/dnd5e/api/authoring/v1alpha1/testdata/floor_plan_edges.textproto
@@ -4,7 +4,13 @@
 # three rooms (6 + 14 + 8 columns), two connector columns, height 8, and
 # door_row 4. It demonstrates the authoring projection without asking clients
 # to derive geometry: an exterior solid wall, an interior-facing solid segment,
-# and a door retaining the source identity generated for its connector.
+# and doors retaining their generated connector identities.
+#
+# Each listed unordered endpoint pair occurs exactly once. Reversing either
+# endpoint pair would describe the same physical edge and MUST NOT be emitted;
+# endpoint order itself has no meaning. This text fixture documents the
+# producer contract, but proto/textproto parsing does not enforce adjacency,
+# uniqueness, kind, or door_id semantics.
 height: 8
 door_row: 4
 rooms: {
@@ -38,7 +44,7 @@ connectors: {
   column: 21
 }
 edges: {
-  # Exterior wall: to.column -1 is outside this plan's [0, 29] floor bounds.
+  # Exterior wall: one endpoint is outside this plan's [0, 29] floor bounds.
   from: { column: 0 row: 0 }
   to: { column: -1 row: 0 }
   kind: FLOOR_PLAN_EDGE_KIND_SOLID
@@ -50,9 +56,16 @@ edges: {
   kind: FLOOR_PLAN_EDGE_KIND_SOLID
 }
 edges: {
-  # Door: source_id exactly retains the matching first connector's opaque ID.
+  # Door identity exactly matches the first connector's door_id.
   from: { column: 5 row: 4 }
   to: { column: 6 row: 4 }
   kind: FLOOR_PLAN_EDGE_KIND_DOOR
-  source_id: "showcase-door-antechamber-shrine"
+  door_id: "showcase-door-antechamber-shrine"
+}
+edges: {
+  # A distinct physical door edge has the second connector's unique door_id.
+  from: { column: 20 row: 4 }
+  to: { column: 21 row: 4 }
+  kind: FLOOR_PLAN_EDGE_KIND_DOOR
+  door_id: "showcase-door-shrine-vault"
 }

--- a/docs/architecture/components/authoring-service.md
+++ b/docs/architecture/components/authoring-service.md
@@ -76,16 +76,29 @@ reconstruct with arithmetic:
   own spawn cell. Distinct from `FloorPlanRoom.archetype == "entrance"`,
   which identifies the entrance *room*, not this cell.
 - `FloorPlan.edges` — the generated canonical solid-wall and door edges.
-  `FloorPlanEdge{from, to, kind, source_id}` is authoring-local: its
-  endpoints use the toolkit's canonical ordering (and an exterior `to` may
-  be outside the floor-plan bounds), while `source_id` preserves the opaque
-  stable source identity where one exists, currently connector doors.
-  Solid edges have no source ID. This projects the generator's truth to the
-  runtime `HexRecord.edges` model after encounter startup; it deliberately
-  does **not** reuse runtime `dnd5e.api.v1alpha2.encounter.Wall` or
-  `WallKind`, because those describe live encounter state. The board renders
-  and hit-tests this list directly; it neither derives competing edges nor
-  restores the retired flat `Space.walls` field.
+  `FloorPlanEdge{from, to, kind, door_id}` is authoring-local. A physical
+  edge is the **undirected** adjacent-cell pair `{from, to}`; the producer
+  emits exactly one record for each pair. Reversed endpoints are the same
+  edge, so duplicate or conflicting records are forbidden. `from`/`to` have
+  no canonical order and clients must not derive direction, ownership, or
+  any other meaning from their orientation. An exterior edge has one endpoint
+  outside the floor-plan bounds.
+
+  `door_id` is required, non-empty, and unique for `DOOR`; for a generated
+  connector door it exactly equals `FloorPlanConnector.door_id`. It is absent
+  for `SOLID`. These are semantic producer requirements, not validations a
+  proto parser/textproto fixture can enforce. At encounter startup, convert
+  each endpoint from FloorPlanCell's `[column, row]` pointy-top offset
+  coordinate into the runtime `Position` cube coordinate. The corresponding
+  runtime `Wall` represents the same unordered pair: `SOLID` becomes
+  `WALL_KIND_SOLID` without `Wall.id`; `DOOR` becomes an initially closed or
+  locked door wall with `Wall.id == door_id` (and may later be
+  `WALL_KIND_DOOR_OPEN`). This projects the generator's truth to runtime
+  `HexRecord.edges`; it deliberately does **not** reuse runtime
+  `dnd5e.api.v1alpha2.encounter.Wall` or `WallKind`, because those describe
+  live encounter state. The board renders and hit-tests this list directly;
+  it neither derives competing edges nor restores the retired flat
+  `Space.walls` field.
 
 ## Error transport — decided, not left to drift between S1 and S4c
 

--- a/docs/architecture/components/authoring-service.md
+++ b/docs/architecture/components/authoring-service.md
@@ -26,8 +26,8 @@ queued).
 
 ## File and shape
 
-- `dnd5e/api/authoring/v1alpha1/service.proto` — 1 service, 1 RPC, 6
-  messages.
+- `dnd5e/api/authoring/v1alpha1/service.proto` — 1 service, 1 RPC, 7
+  messages, and 1 authoring-local edge enum.
 - Imports `dnd5e/api/v1alpha1/common.proto` for `ValidationError` — no new
   error type invented.
 
@@ -75,6 +75,17 @@ reconstruct with arithmetic:
   board is the only thing that can warn an author who blocks the party's
   own spawn cell. Distinct from `FloorPlanRoom.archetype == "entrance"`,
   which identifies the entrance *room*, not this cell.
+- `FloorPlan.edges` — the generated canonical solid-wall and door edges.
+  `FloorPlanEdge{from, to, kind, source_id}` is authoring-local: its
+  endpoints use the toolkit's canonical ordering (and an exterior `to` may
+  be outside the floor-plan bounds), while `source_id` preserves the opaque
+  stable source identity where one exists, currently connector doors.
+  Solid edges have no source ID. This projects the generator's truth to the
+  runtime `HexRecord.edges` model after encounter startup; it deliberately
+  does **not** reuse runtime `dnd5e.api.v1alpha2.encounter.Wall` or
+  `WallKind`, because those describe live encounter state. The board renders
+  and hit-tests this list directly; it neither derives competing edges nor
+  restores the retired flat `Space.walls` field.
 
 ## Error transport — decided, not left to drift between S1 and S4c
 


### PR DESCRIPTION
## Summary

Implements the rpg-api-protos leg of Slice rpg-project#176, tracked by rpg-project#181.

- Adds additive `FloorPlan.edges = 6`, containing authoring-local `FloorPlanEdge{from, to, kind, door_id}` and `FloorPlanEdgeKind` (`SOLID`, `DOOR`); `door_id` is required for `DOOR` edges and absent for `SOLID` edges.
- Documents the projection to runtime `HexRecord.edges`, while intentionally not importing or reusing runtime `dnd5e.api.v1alpha2.encounter.Wall` / `WallKind`; no `Space.walls` field is restored.
- Adds a `showcase.yaml`-grounded textproto fixture covering an exterior wall, interior-facing segment, and connector door with its retained `door_id`.

## Contract decision

`door_id` is required, non-empty, and unique among `DOOR` edges. For a generated connector door, it MUST equal the corresponding `FloorPlanConnector.door_id`; it is absent for `SOLID` edges. Clients preserve this ID rather than synthesizing one; it maps to the runtime `Wall.id`, while canonical endpoints identify the physical geometry record. This keeps the static authoring view separate from runtime door state.

## Validation

- [x] `buf format -w`
- [x] `make test` (lint, format check, generation, mocks)
- [x] `buf breaking --against "https://github.com/KirkDiggler/rpg-api-protos.git#branch=main"`
- [x] `npx tsc --noEmit --project tsconfig.json`
- [x] Generated Go and TypeScript SDKs expose `FloorPlanEdge`, `FloorPlanEdgeKind`, `FloorPlan.edges`, and optional `doorId`; generated Go parses the fixture and verifies the door ID matches its connector.
- [x] Independent self-review: PASS.

The primary checkout contains pre-existing ignored nested worktrees/self-link that make Buf discover duplicate protos; the complete gates above were run in a clean project-local checkout excluding those workspace artifacts (the same source tree CI checks).

Closes #205
Implements https://github.com/KirkDiggler/rpg-project/issues/176
Tracked by https://github.com/KirkDiggler/rpg-project/pull/181

— platform agent, on behalf of KirkDiggler