### PR TITLE
feat(v1alpha1/choices): add category choice options

### DIFF
--- a/dnd5e/api/v1alpha1/choices.proto
+++ b/dnd5e/api/v1alpha1/choices.proto
@@ -126,6 +126,7 @@ message EquipmentCategoryChoice {
   repeated ArmorCategory armor_categories = 3; // Armor categories to choose from
   repeated ToolCategory tool_categories = 4; // Tool categories to choose from
   string label = 5; // Description (e.g., "Choose two martial weapons")
+  repeated EquipmentItem options = 6; // Concrete, enriched, eligible options (optional for backward compatibility)
 }
 
 // Languages that can be chosen


### PR DESCRIPTION
## Status: READY

## What

Adds `repeated EquipmentItem options = 6;` to `EquipmentCategoryChoice` in `dnd5e/api/v1alpha1/choices.proto`.

The real message already owns fields `choose = 1`, `weapon_categories = 2`, `armor_categories = 3`, `tool_categories = 4`, and `label = 5`; this preserves all of them and appends the next unused tag. The stale `options = 4` example in #202 was corrected before implementation. The field reuses existing `EquipmentItem` / `equipment_detail`, so no new message type or API-side rules logic is introduced.

This is additive and wire-compatible: existing consumers see an empty `options` list until rpg-api maps the toolkit-resolved membership.

## Phase 2 links and order

- Approved design/tracking: rpg-project#173
- Provider: rpg-toolkit#877 merged at `bcb0958f2ef5114e601fbf97b043f5f53c9a6d58`, published by annotated tag `rulebooks/dnd5e/v0.70.0` (the tag peels to that exact merge commit)
- Downstream API translation: rpg-api#755

Merge order is toolkit tag → this proto contract → API translation → web adoption. This PR does not bump dependencies, publish/tag, merge, or touch services.

## Generated artifacts and validation

`gen/` is intentionally gitignored and CI-owned; no generated files were edited manually or committed. Regenerated Go/TS bindings and Go mocks only through repository tooling, then verified generated Go has `Options []*EquipmentItem` with protobuf tag `6` and generated TypeScript has `options: EquipmentItem[]`.

Passed locally:

- `buf format -w`
- `buf lint`
- `buf format --diff --exit-code`
- `buf breaking --against 'https://github.com/KirkDiggler/rpg-api-protos.git#branch=main'`
- `buf generate`
- `make mocks`
- `make compile-go`
- `cd tools/refgen && go test ./...` (CI gate)
- `npm ci && make compile-ts`
- `make test` (lint, format check, generation, mocks)
- `git diff --check` and post-generation cleanliness (only the intended proto source diff; generated output remains ignored)

No standalone schema test was added: this repository's documented convention for small additive fields is generation + Go/TS compilation, and comparable prior additive contract PRs carry no proto-shape test. The generated-binding assertions above are the smallest meaningful verification supported by the repo.

## Closes

Closes #202

— asset-pipeline agent, on behalf of KirkDiggler
