### PR TITLE
feat(authoring): add canvas FloorPlan cells

### DIFF
--- a/dnd5e/api/authoring/v1alpha1/service.proto
+++ b/dnd5e/api/authoring/v1alpha1/service.proto
@@ -55,7 +55,8 @@ message FloorPlanConnector {
   int32 column = 5;
 }
 
-// FloorPlanCell is an absolute [column, row] on the compiled grid.
+// FloorPlanCell is an absolute pointy-top odd-q offset [column, row] on the
+// compiled grid.
 message FloorPlanCell {
   int32 column = 1;
   int32 row = 2;
@@ -130,6 +131,15 @@ message FloorPlan {
   // is the only edge list an authoring client renders or hit-tests; no flat
   // runtime Space.walls field exists or may be reintroduced.
   repeated FloorPlanEdge edges = 6;
+  // The compiled canvas width. In canvas mode, rooms is empty and width plus
+  // height bound the canvas; dimensions alone do not describe its floor.
+  int32 width = 7;
+  // Complete canonical structural floor for this plan. Each cell is an
+  // absolute pointy-top odd-q [column, row] coordinate and producers emit
+  // cells in ascending lexicographic (column, row) order. This is required
+  // even in canvas mode: clients MUST render this list, not infer floor from
+  // width and height.
+  repeated FloorPlanCell floor_cells = 8;
 }
 
 // PutDungeonResponse is only ever delivered on a gRPC OK status -- see

--- a/dnd5e/api/authoring/v1alpha1/testdata/floor_plan_canvas.textproto
+++ b/dnd5e/api/authoring/v1alpha1/testdata/floor_plan_canvas.textproto
@@ -1,0 +1,25 @@
+# Contract fixture for the RATIFIED Dungeon YAML Spec v0.3 Wave 0 canvas
+# FloorPlan projection (rpg-api-protos#211).
+#
+# No rooms entries means rooms: []. This complete 3x2 canvas proves a canvas
+# response can carry empty rooms, width, height, every canonical structural
+# floor cell, entrance, and an edge together. floor_cells are absolute
+# pointy-top odd-q [column, row] coordinates in ascending lexicographic
+# (column, row) producer order. Dimensions alone are insufficient: consumers
+# render the explicit floor_cells list.
+width: 3
+height: 2
+floor_cells: { column: 0 row: 0 }
+floor_cells: { column: 0 row: 1 }
+floor_cells: { column: 1 row: 0 }
+floor_cells: { column: 1 row: 1 }
+floor_cells: { column: 2 row: 0 }
+floor_cells: { column: 2 row: 1 }
+entrance: { column: 1 row: 0 }
+edges: {
+  # An authored/generated canonical edge remains part of the canvas projection.
+  from: { column: 1 row: 0 }
+  to: { column: 1 row: 1 }
+  kind: FLOOR_PLAN_EDGE_KIND_DOOR
+  door_id: "canvas-door-1-0-1-1"
+}

--- a/docs/architecture/components/authoring-service.md
+++ b/docs/architecture/components/authoring-service.md
@@ -1,7 +1,7 @@
 ---
 name: AuthoringService
 description: Dev-gated dungeon authoring surface — PutDungeon compiles and (unless validate_only) persists a dungeonspec YAML, returning a server-computed floor plan
-updated: 2026-07-30
+updated: 2026-08-05
 confidence: high — verified by reading dnd5e/api/authoring/v1alpha1/service.proto end-to-end; no consumer yet (rpg-api S1 is the immediate next leg of the same arc)
 ---
 
@@ -67,6 +67,13 @@ reconstruct with arithmetic:
   (dungeonspec's `height/2` invariant), carried explicitly so a future
   non-uniform toolkit change doesn't silently break a board that hardcoded
   the formula.
+- `FloorPlan.width` and existing `height` — canvas dimensions. In the
+  RATIFIED Dungeon YAML Spec v0.3 Wave 0 canvas projection, `rooms` is empty;
+  width/height are bounds, not a substitute for floor geometry.
+- `FloorPlan.floor_cells` — the complete canonical structural floor, using
+  `FloorPlanCell`'s absolute pointy-top odd-q `[column, row]` coordinates.
+  Producers emit ascending lexicographic `(column, row)` order. The board
+  renders this explicit list and MUST NOT infer a floor from dimensions.
 - `FloorPlan.entrance` (`FloorPlanCell{column, row}`) — the
   generator-chosen party spawn anchor (`SpaceData.Entrance`). Added in the
   Opus gate's S0 revision: it's the one value in this contract a client

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -190,8 +190,10 @@ Reuses `dnd5e.api.v1alpha1.ValidationError` for `field_errors` rather
 than inventing a new error type — a deliberate, documented deviation
 from the repo's default `bool success + string error` pattern (see
 [authoring-service.md](components/authoring-service.md)). `FloorPlan`'s
-explicit `start_column`/`column`/`door_row`/`entrance` fields are a clean
-application of "server computes, client never re-derives" — `entrance`
+explicit `start_column`/`column`/`door_row`/`width`/`floor_cells`/`entrance`
+fields are a clean application of "server computes, client never re-derives" —
+`floor_cells` is the complete canonical structural floor, so canvas dimensions
+alone never ask a client to infer geometry; `entrance`
 was added in an Opus-gate revision (design.md names it as one of four
 required response elements; the initial cut had three). The gate's other
 finding on that same pass — design.md's `InvalidArgument` line being


### PR DESCRIPTION
## Summary
- add additive `FloorPlan.width` (tag 7) and `FloorPlan.floor_cells` (tag 8), reusing `FloorPlanCell`
- document complete absolute odd-q floor-cell projection and lexicographic `(column,row)` producer order
- add a canvas contract fixture proving empty rooms, dimensions, complete cells, entrance, and edges coexist

## Validation
- `make test`
- `make breaking`
- `make compile-go`
- `make compile-ts`
- generated Go descriptor/fixture contract check (tags 1–8, empty rooms, ordered cells, entrance, edge)

Generated artifacts are not committed or published from feature branches; CI publishes only after a merge to `main`.

Closes #211