### PR TITLE
feat(encounter): additive ActionResolved.target_rationale (#215)

### DIFF
--- a/dnd5e/api/v1alpha2/encounter/events.proto
+++ b/dnd5e/api/v1alpha2/encounter/events.proto
@@ -266,6 +266,14 @@ message ActionResolved {
   Ref action_ref = 2;
   string target_entity_id = 3; // "" for self/untargeted actions (Dodge, Dash)
   EconomyConsumed economy_consumed = 4; // the real deduction the toolkit made
+  // Reference explaining why this target was chosen. Vocabulary today:
+  // "dnd5e:targeting:lowest-hp" | "dnd5e:targeting:lowest-ac" |
+  // "dnd5e:targeting:closest". Empty = no rationale recorded (player
+  // actions, and non-attack actions, emit empty). This is a reference the
+  // client maps to presentation — never prose.
+  // Refs are open strings for now; expected to firm into an explicit enum
+  // vocabulary the toolkit and game share in a later version.
+  string target_rationale = 5;
 }
 
 // EconomyConsumed is the action-economy delta one ActionResolved spent. Mirrors the


### PR DESCRIPTION
Adds one additive field, `ActionResolved.target_rationale` (field 5), carrying a reference that explains why a monster picked its target. This transcribes vocabulary the consumers already proved rather than inventing it: rpg-toolkit#896 emits `dnd5e:targeting:lowest-hp` / `lowest-ac` / `closest` with round-trip tests asserting the value, and rpg-dnd5e-web#734 renders them in D&D voice (`lowest-hp` → "turns on the most wounded", `lowest-ac` → "picks out the least armored", `closest` deliberately silent). It is a ref the client maps to presentation, never prose, so narration stays a client concern; empty means no rationale recorded, which is what player and non-attack actions emit.

Modeled as `string` rather than the structured `Ref` to match `DamageComponent.source` in this same file, which already carries the toolkit's colon-joined `SourceRef.String()` form. Refs are open strings for now; expected to firm into an explicit enum vocabulary the toolkit and game share in a later version.

Releasing the contract first so the toolkit/api/web wave can pin it (merge inside-out). Unblocks the defensive cast web#734 uses today.

Evidence: `buf lint`, `buf build`, and `buf format --diff --exit-code` all pass clean (format is a no-op). `buf breaking` against `main` produces byte-identical output with and without this change — the only findings are pre-existing and in unrelated files — confirming it is additive. `buf generate` produces `TargetRationale` (Go, tag 5) and `targetRationale` (TS).

Closes #215

— asset-pipeline agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZB1QSaqAphp5J3rdREPR5