### PR TITLE
feat: dnd5e.api.session.v1alpha1 — SessionService mirroring the toolkit session package

### DIFF
--- a/dnd5e/api/session/v1alpha1/events.proto
+++ b/dnd5e/api/session/v1alpha1/events.proto
@@ -1,0 +1,116 @@
+syntax = "proto3";
+
+package dnd5e.api.session.v1alpha1;
+
+option go_package = "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/session/v1alpha1;sessionpb";
+option java_multiple_files = true;
+option java_package = "com.kirkdiggler.rpg.api.dnd5e.session.v1alpha1";
+
+// EventKind names what an event reports. Mirrors session.EventKind.
+//
+// A proto enum, because the SDK says so in as many words: it models EventKind as
+// a string enum rather than free-form prose precisely because "it maps directly
+// onto a proto enum", and it is the field clients branch on.
+//
+// The vocabulary is OPEN TO GROWTH, which is a property of proto3 enums rather
+// than something this file has to build: an unrecognised number is PRESERVED on
+// the wire and readable by the receiver (`EventKind(37)` in Go, the raw number
+// in @bufbuild/es), never dropped and never a parse failure. So a kind the
+// combat train adds (rpg-toolkit#959) reaches an old client intact, and that
+// client's `seq` accounting keeps working — which is the whole point of the
+// SDK's delivered-not-dropped rule. Adding a kind is compatible; changing what
+// an existing one means is not.
+//
+// A parallel `string kind_raw` was considered and rejected: it has no SDK
+// counterpart, and design rule 1 makes inventing one a design change rather than
+// a transcription. The enum already carries what a passthrough string would.
+//
+// UNSPECIFIED and UNKNOWN are different things, and the split follows the
+// house precedent set by HexState in the v1alpha2 encounter package:
+//   - UNSPECIFIED (0) means the producer failed to set a kind. A defect.
+//   - UNKNOWN mirrors the SDK's own session.EventUnknown — a beat THIS VERSION
+//     of the toolkit does not recognise, delivered on purpose rather than
+//     dropped so the recipient still learns its sequence advanced. Dropping it
+//     would manufacture a gap and trigger a resync that was never needed.
+enum EventKind {
+  EVENT_KIND_UNSPECIFIED = 0;
+
+  // A member stepped to a new cell.
+  EVENT_KIND_MOVED = 1;
+  // A member crossed a connection into another room. Distinct from MOVED even
+  // though both are one step in absolute space, because a client may want to
+  // narrate a doorway differently from a corridor.
+  EVENT_KIND_TRAVERSED = 2;
+  // A member entered the encounter.
+  EVENT_KIND_JOINED = 3;
+  // A member left the encounter.
+  EVENT_KIND_EXITED = 4;
+  // The encounter closed.
+  EVENT_KIND_ENDED = 5;
+  // The encounter's opening beat.
+  EVENT_KIND_SCENE_OPENED = 6;
+  // The clock advanced.
+  EVENT_KIND_TICK = 7;
+  // A member's turn in a fight ended and the order moved on.
+  EVENT_KIND_TURN_ENDED = 8;
+  // Two sides came into contact and a fight began, with its initiative order.
+  // Every member of the encounter hears it, not only the ones in the fight: a
+  // fight is localized (the rest of the party keeps free-roaming) but it is not
+  // secret, and a client that learned of it only from the fighters' own
+  // responses could not render the party's shared view of the scene.
+  EVENT_KIND_FIGHT_STARTED = 9;
+  // A fight dissolved and its members returned to free roam.
+  EVENT_KIND_FIGHT_ENDED = 10;
+  // An attack landed. The payload carries the numbers behind it — the roll,
+  // what it totalled, what it had to reach, and how much was done.
+  EVENT_KIND_STRUCK = 11;
+  // An attack did not land. Two kinds rather than one with a hit flag, because
+  // a client branches on them: a landed blow and a whiffed one are different
+  // animations, different sounds, and different things to say. A miss omits the
+  // damage key rather than reporting zero — "missed for 0" reads as a hit that
+  // did nothing.
+  EVENT_KIND_MISSED = 12;
+
+  // A beat the producing toolkit version does not recognise. See the enum
+  // comment: deliberately delivered, and NOT the same as UNSPECIFIED.
+  EVENT_KIND_UNKNOWN = 100;
+}
+
+// Event is one thing that happened, addressed to one recipient. Mirrors
+// session.Event field-for-field (design rule 3), which the SDK shaped flat and
+// non-polymorphic for exactly this mapping: no interface-valued fields, no type
+// switches on the wire, and no payload shape that varies by kind in a way a
+// generated client cannot express.
+//
+// PER-RECIPIENT, NOT PER-OCCURRENCE. The same underlying beat becomes several
+// Events, one per viewer who may know about it, and their payloads may differ.
+// Projection is a rule decided where perception lives — inside the toolkit.
+// rpg-api neither filters nor re-derives visibility (design rule 4); a host that
+// filtered a single shared payload would be reimplementing perception, and its
+// first mistake would leak fog of war.
+message Event {
+  // The session this event belongs to.
+  string session = 1;
+  // The story sequence this event was derived from: monotonic, gapless, and
+  // never renumbered. A recipient that notices a gap has missed an event and
+  // re-queries GetStory from its last known value (design rule 6 — delivery is
+  // best-effort, the story log is truth, and the stream carries no replay
+  // obligation).
+  uint64 seq = 2;
+  // The clock reading when the underlying beat was recorded. The world's clock,
+  // not a wall time — hence uint64 rather than google.protobuf.Timestamp, which
+  // is what the neighbouring v1alpha2 encounter stream uses for its own
+  // (differently defined) timestamp.
+  uint64 at = 3;
+  // Groups cause and effect across events. Empty is legal.
+  string correlation = 4;
+  // The member this projection is addressed to. StreamEvents only ever delivers
+  // events whose recipient is the subscribing member (see StreamEventsRequest),
+  // so this is an assertion the client can check rather than a filter it applies.
+  string recipient = 5;
+  // What happened.
+  EventKind kind = 6;
+  // The kind-specific body, encoded by the toolkit. PASSTHROUGH: rpg-api
+  // round-trips these bytes and never builds or inspects them.
+  bytes payload = 7;
+}

--- a/dnd5e/api/session/v1alpha1/service.proto
+++ b/dnd5e/api/session/v1alpha1/service.proto
@@ -1,0 +1,504 @@
+syntax = "proto3";
+
+package dnd5e.api.session.v1alpha1;
+
+import "dnd5e/api/session/v1alpha1/events.proto";
+import "dnd5e/api/session/v1alpha1/types.proto";
+
+option go_package = "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/session/v1alpha1;sessionpb";
+option java_multiple_files = true;
+option java_package = "com.kirkdiggler.rpg.api.dnd5e.session.v1alpha1";
+
+// SessionService is the wire form of the toolkit's `rulebooks/dnd5e/session`
+// package — one verb surface, transcribed (shapes read from session/v0.9.0).
+//
+// Three rules from rpg-project/ideas/session-api/design.md shape every message
+// below, and are worth reading before adding anything to this file:
+//
+//  1. Messages mirror the SDK's exported input/output types FIELD-FOR-FIELD.
+//     rpg-api invents no vocabulary; a field with no SDK counterpart is a design
+//     change and goes through the design doc first.
+//  2. A VERB'S RESPONSE DESCRIBES ONLY THE CALLER'S OWN ACTION. Everything else
+//     — monsters acting, other members moving, the world waiting — reaches a
+//     client through StreamEvents, single-player included. That is why every
+//     mutating response below is narrow and why the stream is not optional.
+//  5. CREATION IS THE LOBBY'S. The SDK's StartSession and Spawn are deliberately
+//     absent from this service: LobbyService.StartEncounter calls them
+//     in-process. There is no creation RPC here, in v1 or after.
+//
+// Response naming follows the SDK's return shape: where a verb returns a struct
+// its fields are carried directly on the Response (MoveResponse IS
+// session.MoveOutput), and where it returns a slice the Response wraps one
+// repeated field. No Output type is re-wrapped in a single-field envelope.
+
+// =============================================================================
+// Roster
+// =============================================================================
+
+// JoinRequest brings a PLAYER into the session's encounter.
+//
+// Players only, and the split is by where the data comes from rather than by
+// what the thing is: a character is loaded from the host's repository, a monster
+// is built from a ref through Spawn (which is the lobby's, in-process). There is
+// no ref field here and its absence is the point — no toolkit package can load a
+// player character, so a "dnd5e:characters:..." ref would claim otherwise.
+//
+// NOT_FOUND if the session, encounter or character is absent; FAILED_PRECONDITION
+// if the encounter has already ended.
+message JoinRequest {
+  string session = 1;
+  // The joining player's character ID, which is also the ID they are known by
+  // inside the encounter.
+  string member = 2;
+  // The room to place them in.
+  string room = 3;
+  // Where within that room.
+  Position position = 4;
+}
+
+// JoinResponse mirrors session.JoinOutput.
+message JoinResponse {
+  // The joined member's placement.
+  Member member = 1;
+  // The joined character's state, derived after loading. Always populated: a
+  // player with no loadable character does not join at all.
+  CharacterState character = 2;
+  // What changed in each observer's perception, keyed by observer. Absent
+  // observers saw nothing new.
+  map<string, Discovery> discovered = 3;
+  // The story sequence of the recorded join.
+  uint64 seq = 4;
+  // Present if an ending fired on the join.
+  Outcome outcome = 5;
+  // Present if arriving put the newcomer in sight of the other side and a fight
+  // started around them.
+  Formed formed = 6;
+  SaveReport saved = 7;
+  DeliveryReport delivery = 8;
+}
+
+// ExitRequest removes a member from the session's encounter.
+message ExitRequest {
+  string session = 1;
+  string member = 2;
+}
+
+// ExitResponse mirrors session.ExitOutput.
+message ExitResponse {
+  // The member's final placement.
+  MemberOutcome outcome = 1;
+  // What the member knew on the way out — the knowledge that leaves with them
+  // rather than staying with the encounter.
+  repeated Sighting carry = 2;
+  // The story sequence of the recorded exit.
+  uint64 seq = 3;
+  // Present if the encounter auto-closed because the last member left.
+  Outcome closed = 4;
+  SaveReport saved = 5;
+  DeliveryReport delivery = 6;
+}
+
+// =============================================================================
+// Free roam
+// =============================================================================
+
+// MoveRequest walks a member along a path, one cell at a time.
+//
+// A PATH, NOT A DESTINATION. Walking the cells in between is what makes them
+// real: anything that fires because a member entered a particular cell can only
+// be noticed by something that visits each of them. A single-cell path is the
+// ordinary case and entirely legal.
+//
+// Validation is complete before the first cell is entered — a path with a gap is
+// rejected whole rather than walked up to the gap, because a caller who
+// mis-computed a route wants none of it rather than an arbitrary prefix.
+// INVALID_ARGUMENT for an empty or broken path, or a bad position;
+// FAILED_PRECONDITION if the member is in a fight (fights have their own turn
+// structure, which this surface does not expose yet) or the encounter is closed.
+message MoveRequest {
+  string session = 1;
+  string member = 2;
+  // The cells to walk through, in order, each adjacent to the last and the
+  // first adjacent to where the member currently stands.
+  repeated Position path = 3;
+}
+
+// MoveResponse mirrors session.MoveOutput.
+//
+// A SHORT WALK IS NOT AN ERROR. Fewer steps than the requested path means the
+// walk stopped early, and the reason is in outcome or formed; the movement that
+// happened, happened, and it is exactly what the caller asked for up to the
+// point the world changed.
+message MoveResponse {
+  // What actually happened, in order.
+  repeated Step steps = 1;
+  // What changed in each observer's perception across the whole walk, keyed by
+  // observer.
+  map<string, Discovery> discovered = 2;
+  // Present if an ending fired underfoot, which is also why the walk stopped.
+  Outcome outcome = 3;
+  // Present if the walk put the walker in sight of the other side and a fight
+  // started, which is also why the walk stopped. The remaining cells were not
+  // attempted: a fight member does not free-roam.
+  Formed formed = 4;
+  SaveReport saved = 5;
+  DeliveryReport delivery = 6;
+}
+
+// TraverseRequest moves a member through a connection into the adjoining room.
+//
+// TRANSITIONAL (design §0). Under world anchoring the two endpoint cells are
+// adjacent in absolute space, so a crossing is one ordinary step of the same
+// size as any other — a client rendering the result cannot tell a doorway from a
+// corridor. This RPC exists only while the SDK still exposes the verb, and
+// retires when the absolute-projection convergence retires it. New clients
+// should prefer Move where they can.
+message TraverseRequest {
+  string session = 1;
+  string member = 2;
+  // The connection to cross.
+  string connection = 3;
+}
+
+// TraverseResponse mirrors session.TraverseOutput.
+message TraverseResponse {
+  // The room departed.
+  string from_room = 1;
+  // Where the member stood before crossing.
+  Position from = 2;
+  // The room arrived in.
+  string to_room = 3;
+  // Where the member arrived.
+  Position to = 4;
+  // What changed in each observer's perception, keyed by observer.
+  map<string, Discovery> discovered = 5;
+  // The story sequence of the recorded crossing.
+  uint64 seq = 6;
+  // Present if an ending fired on arrival.
+  Outcome outcome = 7;
+  // Present if walking through the doorway put the crosser in sight of the
+  // other side and a fight started.
+  Formed formed = 8;
+  SaveReport saved = 9;
+  DeliveryReport delivery = 10;
+}
+
+// =============================================================================
+// Fight
+// =============================================================================
+
+// AttackRequest swings one member's weapon at another.
+//
+// MEMBER-NEUTRAL ON PURPOSE, mirroring the SDK: both sides are IDs and nothing
+// here is character-shaped, even though v1 compiles CHARACTER attackers only
+// (a monster attacker is refused FAILED_PRECONDITION, from the SDK's
+// ErrNotACharacter). Scope by the case, shape for the future — the day a monster
+// attacker compiles, this message does not change and no client that wrote
+// against it has to.
+//
+// Two known gaps the SDK names and this contract inherits verbatim: main hand,
+// one-handed, melee only; and NOTHING SPENDS — a character can attack as many
+// times in a turn as the caller asks, because the economy that would spend
+// something sits above this seam and does not exist yet.
+message AttackRequest {
+  string session = 1;
+  // Who swings.
+  string attacker = 2;
+  // Who they swing at.
+  string target = 3;
+}
+
+// AttackResponse mirrors session.AttackOutput.
+message AttackResponse {
+  // The d20 as rolled, after any advantage or disadvantage.
+  int32 roll = 1;
+  // The roll plus everything the attack chain added.
+  int32 total = 2;
+  // The number the total had to reach.
+  int32 against = 3;
+  bool hit = 4;
+  bool critical = 5;
+  // What was dealt. Zero on a miss.
+  int32 damage = 6;
+  // The story sequence of the recorded beat.
+  uint64 seq = 7;
+  SaveReport saved = 8;
+  DeliveryReport delivery = 9;
+}
+
+// TurnRequest asks what one member is waiting on.
+//
+// ASKED OF A MEMBER, NEVER OF THE SESSION, and that is not a convenience choice.
+// Several clocks can run at once — a fight in the crypt while the rest of the
+// party explores the hall — so "whose turn is it?" has no answer here and never
+// will. A top-level query would have to pick one privileged clock to be THE
+// clock, and every client written against it would need rewriting the first time
+// a second fight started. GetStatus deliberately learns nothing per-member for
+// the same reason.
+message TurnRequest {
+  string session = 1;
+  string member = 2;
+}
+
+// TurnResponse mirrors session.TurnOutput.
+message TurnResponse {
+  // Which kind of time they are in.
+  ClockKind clock = 1;
+  // Whose turn it currently is on that clock. Empty on the world clock, which
+  // has no turn order.
+  string active = 2;
+  // Which round that clock is in. Zero on the world clock.
+  int32 round = 3;
+  // The initiative order of the fight they are in, first to act first. Empty on
+  // the world clock.
+  repeated string order = 4;
+}
+
+// EndTurnRequest ends a member's turn and hands the fight to whoever is next.
+//
+// There is deliberately no "end the current turn" form — that would be the
+// privileged-clock question wearing a verb's clothes (see TurnRequest).
+// FAILED_PRECONDITION if the member is not in a fight or it is not their turn.
+message EndTurnRequest {
+  string session = 1;
+  // Whose turn is ending — and it must be THEIR turn.
+  string member = 2;
+}
+
+// EndTurnResponse mirrors session.EndTurnOutput.
+message EndTurnResponse {
+  // Who acts now.
+  string next = 1;
+  // Whether that was the last turn of the round, so the order has come back
+  // around.
+  bool round_wrapped = 2;
+  // The story sequence of the recorded beat.
+  uint64 seq = 3;
+  SaveReport saved = 4;
+  DeliveryReport delivery = 5;
+}
+
+// DissolveRequest ends the fight a member is in and returns everyone to free
+// roam.
+//
+// A fight is reached THROUGH a member rather than by name, because it has no
+// name: the composition models a bubble as something you find by asking who is
+// in it.
+//
+// This is the half of ending a fight that a verb can fix — the party deciding to
+// disengage. Defeat is the other half and will never be a second verb: it is a
+// fact the world notices, so it arrives as another DissolveKind produced by the
+// composition, not as a caller-invoked mechanism.
+message DissolveRequest {
+  string session = 1;
+  // Anyone in the fight.
+  string member = 2;
+  // Why it is ending. Required — a caller that will not say why is asking for
+  // an effect without an account of it. The SDK models this as a sealed
+  // interface whose declared wire form is exactly this enum.
+  DissolveKind cause = 3;
+}
+
+// DissolveResponse mirrors session.DissolveOutput.
+message DissolveResponse {
+  // Everyone who was in it, now back on the world clock. Time spent fighting is
+  // spent, not banked: everyone re-homes at budget zero.
+  repeated string members = 1;
+  // Why it ended, echoed for a caller handling the response.
+  DissolveKind cause = 2;
+  // The story sequence of the recorded beat.
+  uint64 seq = 3;
+  SaveReport saved = 4;
+  DeliveryReport delivery = 5;
+}
+
+// =============================================================================
+// Endings
+// =============================================================================
+
+// EndRequest closes the session's encounter through a declared EXTERNAL ending.
+//
+// Endings are declared when a world is authored, so NOT_FOUND here means the
+// caller named something that was never on the menu — not that the encounter is
+// missing.
+message EndRequest {
+  string session = 1;
+  // The key of the declared external ending to fire.
+  string ending = 2;
+}
+
+// EndResponse mirrors session.EndOutput.
+message EndResponse {
+  // The final state: which ending fired and where everyone stood.
+  Outcome outcome = 1;
+  SaveReport saved = 2;
+  DeliveryReport delivery = 3;
+}
+
+// =============================================================================
+// Reads
+// =============================================================================
+
+// GetStatusRequest asks whether a session's encounter is open.
+message GetStatusRequest {
+  string session = 1;
+}
+
+// GetStatusResponse mirrors session.Status.
+//
+// Encounter-wide and NEVER per-member — pinned by the SDK rather than merely
+// unimplemented. A convenience field here answering "the" active actor would
+// create a privileged clock by implication; ask TurnRequest instead.
+message GetStatusResponse {
+  // Whether the encounter is active.
+  bool open = 1;
+  // The ending that fired, present only once closed.
+  Outcome outcome = 2;
+}
+
+// GetStoryRequest reads the beats a member has witnessed.
+//
+// THE RESYNC SOURCE OF TRUTH (design rule 6). Delivery on StreamEvents is
+// best-effort and carries no replay obligation; a client that notices a gap in
+// `seq` re-queries here from its last known value.
+//
+// NOT_FOUND with the SDK's ErrStoryTrimmed semantics means the requested resume
+// point has aged out of the retention window and the caller must resync from
+// zero rather than resume — a short answer would be indistinguishable from a
+// complete one and would leave a permanent hole in the client's view.
+message GetStoryRequest {
+  string session = 1;
+  // The viewer whose story is requested.
+  string member = 2;
+  // The INCLUSIVE lower bound: entries begin AT this sequence. To resume after
+  // entry N, pass N+1. Zero means "I hold nothing, send what you have" and is
+  // always answerable, however much has aged out.
+  uint64 from_seq = 3;
+}
+
+// GetStoryResponse carries session.Story's return slice.
+message GetStoryResponse {
+  repeated StoryEntry entries = 1;
+}
+
+// GetViewRequest asks what one member currently perceives.
+message GetViewRequest {
+  string session = 1;
+  // The observer.
+  string member = 2;
+}
+
+// GetViewResponse carries session.View's return slice.
+//
+// A cold client cannot yet learn its OWN position from this: View reports what a
+// member perceives and skips self. That gap is SDK-first work (design rule 11,
+// toolkit#933) and explicitly not a gate on this package — until it lands,
+// reconnect leans on GetStory replay.
+message GetViewResponse {
+  repeated Sighting sightings = 1;
+}
+
+// GetAtlasRequest asks for a session's static world map.
+message GetAtlasRequest {
+  string session = 1;
+}
+
+// GetAtlasResponse mirrors session.Atlas.
+//
+// CONSTRUCTION TRUTH — unchanged by movement, joins, exits or endings. Fetch it
+// once per encounter and cache it; never per frame.
+message GetAtlasResponse {
+  // Every room's absolute footprint, sorted by room ID.
+  repeated AtlasRoom rooms = 1;
+  // Every connection's absolute endpoint pair, sorted by connection ID.
+  repeated AtlasDoorway doorways = 2;
+}
+
+// =============================================================================
+// Stream
+// =============================================================================
+
+// StreamEventsRequest subscribes to the events addressed to one member.
+//
+// `member` is the RECIPIENT IDENTITY, and the server delivers only events whose
+// Event.recipient is that member — verbatim, as the toolkit projected them.
+// rpg-api neither filters nor re-derives visibility (design rule 4): events
+// arrive from the SDK already projected per audience, so the wire only ever
+// carries what the recipient may see. A host that filtered would be
+// reimplementing perception, and its first mistake would leak fog of war.
+//
+// Unlike StreamLobby, the subscriber is a request field rather than purely the
+// authenticated identity: one authenticated player controls one member today,
+// but the recipient of a projection is an encounter member, and the two are not
+// the same vocabulary. Servers MUST still verify the caller is entitled to that
+// member's stream.
+//
+// No snapshot-then-deltas here, deliberately — this stream has no replay
+// obligation. A subscriber that needs to catch up reads GetStory, and one that
+// needs the static map reads GetAtlas.
+message StreamEventsRequest {
+  string session = 1;
+  string member = 2;
+}
+
+// =============================================================================
+// Service
+// =============================================================================
+
+service SessionService {
+  // Join brings a player into the encounter and reports what came into view as
+  // a result. Creation is the lobby's — there is no StartSession here.
+  rpc Join(JoinRequest) returns (JoinResponse);
+
+  // Exit removes a member, returning what they knew on the way out. The last
+  // member leaving auto-closes the encounter (ExitResponse.closed).
+  rpc Exit(ExitRequest) returns (ExitResponse);
+
+  // Move walks a member along a path, one cell at a time. A short walk is an
+  // answer, not an error.
+  rpc Move(MoveRequest) returns (MoveResponse);
+
+  // Traverse crosses a connection. TRANSITIONAL (design §0): at the destination
+  // a doorway crossing is an ordinary Move step, and this RPC retires with the
+  // SDK verb it mirrors.
+  rpc Traverse(TraverseRequest) returns (TraverseResponse);
+
+  // Attack swings one member's weapon at another. Character attackers only in
+  // v1; nothing spends yet.
+  rpc Attack(AttackRequest) returns (AttackResponse);
+
+  // Turn reports what one member is waiting on. Asked of a member, never of the
+  // session.
+  rpc Turn(TurnRequest) returns (TurnResponse);
+
+  // EndTurn ends a member's turn and hands the fight to whoever is next.
+  rpc EndTurn(EndTurnRequest) returns (EndTurnResponse);
+
+  // Dissolve ends the fight a member is in, by decision. Defeat is not a caller
+  // verb and never will be.
+  rpc Dissolve(DissolveRequest) returns (DissolveResponse);
+
+  // End closes the encounter through a declared external ending.
+  rpc End(EndRequest) returns (EndResponse);
+
+  // GetStatus reports whether the encounter is open, and how it ended if not.
+  rpc GetStatus(GetStatusRequest) returns (GetStatusResponse);
+
+  // GetStory reads the beats a member has witnessed — the resync source of
+  // truth when the stream drops a beat or a client reconnects.
+  rpc GetStory(GetStoryRequest) returns (GetStoryResponse);
+
+  // GetView reports what one member currently perceives.
+  rpc GetView(GetViewRequest) returns (GetViewResponse);
+
+  // GetAtlas returns the static world map. Construction truth; cache per
+  // encounter.
+  rpc GetAtlas(GetAtlasRequest) returns (GetAtlasResponse);
+
+  // StreamEvents delivers the events addressed to one member. Everything a
+  // client must render that is not the caller's own action arrives here —
+  // monsters acting, the clock advancing, another member crossing a doorway —
+  // single-player included (design rule 2). Best-effort: a recipient that
+  // notices a gap in Event.seq re-queries GetStory (rule 6).
+  rpc StreamEvents(StreamEventsRequest) returns (stream Event);
+}

--- a/dnd5e/api/session/v1alpha1/types.proto
+++ b/dnd5e/api/session/v1alpha1/types.proto
@@ -1,0 +1,357 @@
+syntax = "proto3";
+
+package dnd5e.api.session.v1alpha1;
+
+option go_package = "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/session/v1alpha1;sessionpb";
+option java_multiple_files = true;
+option java_package = "com.kirkdiggler.rpg.api.dnd5e.session.v1alpha1";
+
+// This package transcribes the exported surface of the toolkit's
+// `rulebooks/dnd5e/session` package (read from session/v0.9.0). Every message
+// here mirrors an SDK type field-for-field: rpg-api invents no vocabulary, and
+// a field with no SDK counterpart is a design change that goes through
+// rpg-project/ideas/session-api/design.md first (rule 1).
+//
+// The SDK's own laws that shape this file:
+//   - S2: no inner type crosses the boundary. What the session package exports
+//     is what the wire carries; nothing here reaches past it into encounter,
+//     combat, clock, intel or record types.
+//   - Every string enum the SDK owns exists BECAUSE it maps onto a proto enum
+//     (its words). Each one is transcribed as an enum below, not as a string.
+
+// =============================================================================
+// Enums
+// =============================================================================
+
+// ClockKind names which kind of time a member is living in. Mirrors
+// session.ClockKind ("world" / "turn").
+//
+// A member is always in exactly one kind of time — that totality is what makes
+// the SDK's ErrInBubble / ErrNotInFight pair meaningful. UNSPECIFIED means the
+// producer failed to set it; treat it as a defect, not as a third clock.
+enum ClockKind {
+  CLOCK_KIND_UNSPECIFIED = 0;
+  // Free roam. Everyone acts; their own movement advances the clock and there
+  // is no turn order to be next in.
+  CLOCK_KIND_WORLD = 1;
+  // A fight. The members in it act in an order, one at a time.
+  CLOCK_KIND_TURN = 2;
+}
+
+// DissolveKind names why a fight ended. Mirrors session.DissolveKind, which the
+// SDK documents as the wire form of its sealed session.DissolveCause interface.
+//
+// Deliberately a closed set with one member. The SDK seals DissolveCause with an
+// unexported method so a second cause cannot be declared outside that package —
+// defeat, when the composition can see it, arrives as another CALLER of that
+// shape rather than as a second way to end a fight. Adding a value here waits on
+// the SDK adding one, exactly as the seal intends.
+enum DissolveKind {
+  DISSOLVE_KIND_UNSPECIFIED = 0;
+  // A fight its members chose to walk away from (session.ByDecision).
+  DISSOLVE_KIND_BY_DECISION = 1;
+}
+
+// GridKind names a room's coordinate family. Mirrors session.GridKind
+// ("square" / "hex").
+//
+// The SDK models this as a string rather than mirroring spatial's iota, for the
+// reason it gives: an iota is an in-process enumeration order, not a wire
+// contract, and reordering it upstream would silently reinterpret every stored
+// and transmitted value. A named proto enum has the same property.
+enum GridKind {
+  GRID_KIND_UNSPECIFIED = 0;
+  // Square grid, where distance is Chebyshev.
+  GRID_KIND_SQUARE = 1;
+  // Hex grid addressed in axial coordinates, where distance is measured in
+  // cube space.
+  GRID_KIND_HEX = 2;
+}
+
+// MemberKind categorises a member. Mirrors session.MemberKind
+// ("player" / "monster").
+enum MemberKind {
+  MEMBER_KIND_UNSPECIFIED = 0;
+  // A player-controlled member.
+  MEMBER_KIND_PLAYER = 1;
+  // A member driven by the game rather than a person.
+  MEMBER_KIND_MONSTER = 2;
+}
+
+// =============================================================================
+// Spatial
+// =============================================================================
+
+// Position mirrors spatial.Position (tools/spatial v0.9.1) — the one value type
+// the session SDK lets across its boundary, and therefore the one this contract
+// must match rather than choose.
+//
+// Minted here rather than reusing an existing Position, deliberately, and both
+// candidates were checked:
+//
+//   - `api.v1alpha1.Position` is int32 x/y/z cube coordinates. Reusing it would
+//     change the type and add an axis the SDK does not have — not a
+//     field-for-field mirror (rule 1), and a lossy cast at every boundary.
+//   - `dnd5e.api.v1alpha2.encounter.Position` is the same int32 cube shape AND
+//     lives in the package the cutover deletes. Importing it would create a
+//     path between SessionService and the old encounter stack, which rule 9
+//     forbids outright.
+//
+// The FRAME is per-field, not global, because the SDK's is: Atlas coordinates
+// are dungeon-absolute, while a member's placement (JoinRequest.position,
+// MemberOutcome.position) is scoped to the room named alongside it. Design §0's
+// ruling — the session package speaks one map — is the destination the SDK
+// converges on; the protos follow each reshape rather than pre-declaring it.
+message Position {
+  double x = 1;
+  double y = 2;
+}
+
+// =============================================================================
+// Roster
+// =============================================================================
+
+// Member is one participant's placement in the encounter. Mirrors
+// session.Member.
+message Member {
+  string id = 1;
+  MemberKind kind = 2;
+  // The room the member currently occupies.
+  string room = 3;
+}
+
+// MemberOutcome is where a member stood when something closed around them.
+// Mirrors session.MemberOutcome.
+message MemberOutcome {
+  string id = 1;
+  // The room they were in.
+  string room = 2;
+  // Where they stood within it.
+  Position position = 3;
+}
+
+// CharacterState is what a loaded character reports about itself. Mirrors
+// session.CharacterState.
+//
+// The SDK's own twin of a stored character, not the stored shape: this is what
+// one call observed after reconstitution. Deliberately small — it carries what
+// a client needs to render a member and what proves the load happened, not the
+// sheet in full.
+message CharacterState {
+  string id = 1;
+  string name = 2;
+  int32 level = 3;
+  // BASE walking speed in feet, from race — not effective speed. Condition-
+  // driven modifiers are applied during resolution through the movement chain,
+  // never folded in here. A client rendering this shows the sheet's speed, not
+  // what the next step will cost.
+  int32 speed = 4;
+  int32 hit_points = 5;
+  int32 max_hit_points = 6;
+  int32 armor_class = 7;
+  int32 proficiency_bonus = 8;
+}
+
+// =============================================================================
+// Perception
+// =============================================================================
+
+// Report is one thing an observer perceived. Mirrors session.Report.
+message Report {
+  // What was perceived.
+  string subject = 1;
+  // What the observer learned, encoded by the composition. Opaque here: rpg-api
+  // round-trips these bytes and never builds them (rule 1's corollary — the
+  // host invents no vocabulary, including inside a payload).
+  bytes payload = 2;
+}
+
+// Discovery is what changed in one observer's perception. Mirrors
+// session.Discovery.
+//
+// Three disjoint lists rather than one "here is everything you now perceive",
+// because a client renders them differently: a first sighting is announced, a
+// refresh updates silently, a fade greys something out. Collapsing them would
+// force the client to diff against its own previous state to recover a
+// distinction the composition already knows.
+message Discovery {
+  // What came into view that the observer did not hold at all — the moments
+  // worth announcing.
+  repeated Report first_contact = 1;
+  // Subjects the observer already held whose knowledge was renewed by a live
+  // channel.
+  repeated string refreshed = 2;
+  // Subjects that stopped being sustained. The observer keeps a memory; it is
+  // no longer a live sighting.
+  repeated string faded = 3;
+}
+
+// Sighting is one thing an observer currently knows about. Mirrors
+// session.Sighting.
+//
+// `channel` and `status` are free-form strings in the SDK, and stay strings
+// here. Promoting them to enums would be rpg-api inventing a closed vocabulary
+// the toolkit has not committed to (rule 1) — the opposite of what the enums
+// above do, which is transcribe vocabularies the SDK already sealed.
+message Sighting {
+  // What is perceived.
+  string subject = 1;
+  // What the observer knows about it, encoded by the composition.
+  bytes payload = 2;
+  // How it was perceived.
+  string channel = 3;
+  // The clock reading when this knowledge was last refreshed. A clock reading,
+  // not a wall time — see StoryEntry.at.
+  uint64 at = 4;
+  // The channels currently carrying it. Empty means the observer holds a
+  // memory rather than a live sighting.
+  repeated string current_via = 5;
+  // Distinguishes a live sighting from a stale memory.
+  string status = 6;
+}
+
+// =============================================================================
+// Movement, fights, endings
+// =============================================================================
+
+// Step is one cell entered during a walk. Mirrors session.Step.
+message Step {
+  Position position = 1;
+  // The story sequence of the recorded step.
+  uint64 seq = 2;
+}
+
+// Outcome is how an encounter closed. Mirrors session.Outcome.
+message Outcome {
+  // The key of the ending that fired.
+  string ending = 1;
+  // The clock reading when it fired.
+  uint64 at = 2;
+  // Where everyone stood when it closed.
+  repeated MemberOutcome members = 3;
+}
+
+// Formed reports that a fight started, and who is in it. Mirrors
+// session.Formed.
+//
+// It is NEWS, not a decision anyone made: the composition detects contact
+// wherever sight changes and starts the fight itself, and whichever verb caused
+// it carries the report back. A client renders "roll for initiative" from this;
+// it never asks for one. That is why it appears on every verb that can put two
+// sides in sight of each other — a walk, a doorway, an arrival.
+message Formed {
+  // The fight's initiative order, first to act first.
+  repeated string order = 1;
+  // The members who entered unaware, a subset of order. Empty under symmetric
+  // sight, which is a law as of spatial v0.9.1; it fills when asymmetric
+  // perception arrives deliberately (stealth against perception,
+  // rpg-toolkit#1020), never through geometry.
+  repeated string surprised = 2;
+  // The story sequence of the beat that recorded the fight starting.
+  uint64 seq = 3;
+}
+
+// =============================================================================
+// Reports every mutating verb carries back
+// =============================================================================
+
+// SaveReport names which aggregates were persisted and which were not. Mirrors
+// session.SaveReport.
+//
+// A partial save is an error carrying a populated report, never a silent shrug
+// (the SDK's law S6). Both lists non-empty means the world is half-written and
+// the caller needs to know which half.
+message SaveReport {
+  repeated string written = 1;
+  repeated string failed = 2;
+}
+
+// DeliveryReport says what reached the event stream. Mirrors
+// session.DeliveryReport.
+//
+// Separate from SaveReport because they answer different questions with
+// different consequences: a failed save means the world did not change, while a
+// failed delivery means it DID and some clients have not heard yet. Conflating
+// them would leave a caller unable to tell "retry this" from "this happened,
+// tell them again."
+message DeliveryReport {
+  // How many per-recipient events were handed to the stream.
+  int32 events = 1;
+  // Delivery did not succeed. The verb still succeeded: the story log is the
+  // source of truth, sequences are gapless, and a client that misses an event
+  // notices the hole and re-queries GetStory.
+  bool failed = 2;
+}
+
+// =============================================================================
+// Story
+// =============================================================================
+
+// StoryEntry is one recorded beat. Mirrors session.StoryEntry.
+//
+// The story log is truth (design rule 6): the event stream is best-effort, and
+// GetStory is what a client that noticed a gap in `seq` reads to catch up.
+message StoryEntry {
+  // Monotonic, gapless, never renumbered. A client that notices a gap has
+  // missed a beat and should re-query.
+  uint64 seq = 1;
+  // The clock reading when the beat was recorded — the world's own clock, not a
+  // wall time, which is why this is a uint64 and not a google.protobuf.Timestamp.
+  uint64 at = 2;
+  // Groups cause and effect across beats. Empty is legal.
+  string correlation = 3;
+  // Queryable metadata describing the beat.
+  map<string, string> tags = 4;
+  // The beat itself, encoded by the composition. Passthrough.
+  bytes payload = 5;
+}
+
+// =============================================================================
+// Atlas — the static world map
+// =============================================================================
+
+// AtlasBoundary is one wall or barrier crossing between adjacent cells. Mirrors
+// session.AtlasBoundary. Both endpoints are dungeon-absolute.
+message AtlasBoundary {
+  Position from = 1;
+  Position to = 2;
+  // Whether an entity may cross.
+  bool blocks_movement = 3;
+  // Whether sight may cross.
+  bool blocks_line_of_sight = 4;
+}
+
+// AtlasRoom is one room's absolute-space footprint. Mirrors session.AtlasRoom.
+message AtlasRoom {
+  string id = 1;
+  GridKind grid = 2;
+  // The room's dungeon-absolute anchor.
+  Position origin = 3;
+  int32 width = 4;
+  int32 height = 5;
+  // Every cell of the room in dungeon-absolute space, occluded cells included:
+  // occlusion is walkability, not ownership.
+  repeated Position cells = 6;
+  // The subset of `cells` that blocks line of sight, reported separately so a
+  // host can render them distinctly.
+  repeated Position occluders = 7;
+  repeated AtlasBoundary boundaries = 8;
+}
+
+// AtlasDoorway is one connection's absolute endpoint pair. Mirrors
+// session.AtlasDoorway.
+//
+// The two cells are adjacent in absolute space, so crossing one is an ordinary
+// step — which is design §0's ruling visible in the SDK's own shapes, and the
+// reason Traverse is transitional.
+message AtlasDoorway {
+  string connection = 1;
+  // The source room ID.
+  string from = 2;
+  // The endpoint in `from`, dungeon-absolute.
+  Position from_cell = 3;
+  // The destination room ID.
+  string to = 4;
+  // The endpoint in `to`, dungeon-absolute.
+  Position to_cell = 5;
+}

--- a/dnd5e/api/session/v1alpha1/types.proto
+++ b/dnd5e/api/session/v1alpha1/types.proto
@@ -48,7 +48,9 @@ enum ClockKind {
 // the SDK adding one, exactly as the seal intends.
 enum DissolveKind {
   DISSOLVE_KIND_UNSPECIFIED = 0;
-  // A fight its members chose to walk away from (session.ByDecision).
+  // A fight its members chose to walk away from. Named after the SDK constant
+  // it mirrors, session.DissolveByDecision — whose own string value is
+  // "decision", and which session.ByDecision() is the cause constructor for.
   DISSOLVE_KIND_BY_DECISION = 1;
 }
 

--- a/docs/architecture/components/session-service.md
+++ b/docs/architecture/components/session-service.md
@@ -1,0 +1,170 @@
+---
+name: SessionService
+description: D&D 5e session contract (v1alpha1) — the wire transcription of the toolkit's session package; the surface that replaces the v1alpha2 encounter stack
+updated: 2026-08-16
+confidence: high — proto-side only; no consumer yet, verified by scripted field-for-field comparison against rulebooks/dnd5e/session v0.9.0
+---
+
+# SessionService
+
+Defined in `dnd5e/api/session/v1alpha1/` (service-first layout:
+`service.proto`, `types.proto`, `events.proto` — the split
+`dnd5e/api/v1alpha2/encounter/` set and `dnd5e/api/lobby/v1alpha1/` followed).
+Package `dnd5e.api.session.v1alpha1`.
+
+Design doc: `rpg-project/ideas/session-api/design.md`. Umbrella:
+`KirkDiggler/rpg-project#227`. Landed by rpg-api-protos#222 (issue #221) as W1
+of that initiative.
+
+## What makes this service different from every other one here
+
+**It is a transcription, not a design.** The toolkit's
+`rulebooks/dnd5e/session` package is the game server's single point of contact
+with the rules engine, and it already exposes exactly one verb surface. This
+package mirrors that surface field-for-field. rpg-api invents no vocabulary:
+per the design's rule 1, a proto field with no SDK counterpart is a *design
+change* and goes through the design doc before it goes into the proto.
+
+That constraint is the reason several shapes here look unlike the rest of the
+repo, and each apparent oddity is the SDK's, faithfully carried:
+
+- `Position` is `double x/y` — two axes, floating point — because
+  `spatial.Position` is. It is **not** the repo's `int32` cube `Position`.
+  See [data-model.md](../data-model.md#position) for the three-Position
+  situation and why reuse was rejected rather than overlooked.
+- Responses are the SDK's Output structs flattened, not envelopes.
+  `MoveResponse` *is* `session.MoveOutput`.
+- `SaveReport` and `DeliveryReport` ride on every mutating response, because
+  the SDK reports persistence and delivery as separate facts with different
+  consequences (a failed save means the world did not change; a failed
+  delivery means it did and some clients have not heard).
+- Free-form SDK strings (`Sighting.channel`, `Sighting.status`) stay strings.
+  Promoting them to enums would be inventing a closed vocabulary the toolkit
+  has not committed to.
+
+## RPCs
+
+Fourteen, mirroring the SDK verbs one-for-one.
+
+| RPC | SDK verb | Request:Response | Notes |
+|---|---|---|---|
+| `Join` | `Join` | `JoinRequest:JoinResponse` | Players only. Character is loaded before placement, so a member with no loadable sheet never joins |
+| `Exit` | `Exit` | `ExitRequest:ExitResponse` | Returns the knowledge that leaves with the member (`carry`); last member out auto-closes the encounter (`closed`) |
+| `Move` | `Move` | `MoveRequest:MoveResponse` | A **path**, not a destination. Fewer `steps` than requested `path` is an answer, not an error — the reason is in `outcome` or `formed` |
+| `Traverse` | `Traverse` | `TraverseRequest:TraverseResponse` | **Transitional.** See below |
+| `Attack` | `Attack` | `AttackRequest:AttackResponse` | Character attackers only in v1; nothing spends yet |
+| `Turn` | `Turn` | `TurnRequest:TurnResponse` | Asked of a **member**, never of the session. See below |
+| `EndTurn` | `EndTurn` | `EndTurnRequest:EndTurnResponse` | No "end the current turn" form, for the same reason `Turn` takes a member |
+| `Dissolve` | `Dissolve` | `DissolveRequest:DissolveResponse` | Cause required. The fight is reached *through* a member, because a fight has no name |
+| `End` | `End` | `EndRequest:EndResponse` | Declared external endings only — `NotFound` means the key was never on the menu |
+| `GetStatus` | `Status` | `GetStatusRequest:GetStatusResponse` | Encounter-wide, never per-member |
+| `GetStory` | `Story` | `GetStoryRequest:GetStoryResponse` | The resync source of truth |
+| `GetView` | `View` | `GetViewRequest:GetViewResponse` | Sightings. Skips self — see the known gap below |
+| `GetAtlas` | `Atlas` | `GetAtlasRequest:GetAtlasResponse` | Static; cache per encounter, never per frame |
+| `StreamEvents` | `EventStream` | `StreamEventsRequest:stream Event` | Per-recipient projections |
+
+**No `StartSession` and no `Spawn`**, though the SDK exposes both. Creation is
+the lobby's: `LobbyService.StartEncounter` calls them in-process (design rule
+5). There is no creation RPC on this service in v1 or after.
+
+## The event spine
+
+`Event` (`events.proto`) mirrors `session.Event` exactly — `session`, `seq`,
+`at`, `correlation`, `recipient`, `kind`, `payload`. The SDK's own godoc says
+it was shaped flat and non-polymorphic *for this mapping*: no interface-valued
+fields, no type switches on the wire, no payload shape that varies by kind in
+a way a generated client cannot express.
+
+Three properties worth holding onto:
+
+- **Per-recipient, not per-occurrence.** One underlying beat becomes several
+  `Event`s, one per viewer who may know about it, and their payloads may
+  differ. Projection happens inside the toolkit, where perception lives.
+- **rpg-api never filters.** `StreamEvents(session, member)` delivers events
+  whose `recipient` is that member, verbatim (design rule 4). A host that
+  filtered would be reimplementing visibility, and its first mistake would leak
+  fog of war.
+- **Delivery is best-effort; the story log is truth** (design rule 6). `seq` is
+  monotonic and gapless per session. A client that notices a gap re-queries
+  `GetStory` from its last known value. The stream carries no replay
+  obligation, which is why there is no snapshot-then-deltas pattern here — the
+  shape `StreamEncounter` and `StreamLobby` both use.
+
+`EventKind` is a proto enum with 13 named values plus `UNSPECIFIED`. It is
+**open to growth by construction**: proto3 preserves an unrecognised enum
+number rather than dropping it, so a kind added later (rpg-toolkit#959) reaches
+an old client intact and that client's `seq` accounting keeps working.
+
+`EVENT_KIND_UNSPECIFIED` (0) and `EVENT_KIND_UNKNOWN` (100) are deliberately
+different: 0 means the producer failed to set a kind (a defect), while
+`UNKNOWN` mirrors the SDK's own `session.EventUnknown` — a beat *this toolkit
+version* does not recognise, delivered on purpose so the recipient still learns
+its sequence advanced. Same distinction `HexState` draws in the v1alpha2
+encounter package.
+
+## Contract edge cases (decided by the SDK, transcribed rather than re-decided)
+
+- **`Traverse` is transitional.** Per design §0, Kirk's ruling is that the
+  encounter has rooms but projects dungeon-absolute geometry, so the session
+  package sees one map. At that destination a doorway crossing is an ordinary
+  `Move` step, and a client cannot tell a doorway from a corridor. The RPC
+  exists while the SDK exposes the verb and retires when the SDK's
+  absolute-projection convergence retires it. New clients should prefer `Move`.
+
+- **`Turn` is asked of a member, never of the session.** Several clocks can run
+  at once — a fight in the crypt while the rest of the party explores the hall
+  — so "whose turn is it?" has no answer. A top-level query would have to pick
+  one privileged clock to be *the* clock. `GetStatus` is correspondingly
+  encounter-wide and must never learn anything per-member; the SDK pins this
+  rather than merely leaving it unimplemented.
+
+- **A verb's response describes only the caller's own action** (design rule 2).
+  Monsters acting, other members moving, the world waiting — none of it appears
+  in anyone's return value. It reaches a client through `StreamEvents`,
+  single-player included. This is why the stream is not optional.
+
+- **`Formed` appears on every verb that can put two sides in sight of each
+  other** (`Join`, `Move`, `Traverse`). A fight is *news*, not a decision: the
+  composition detects contact wherever sight changes and starts the fight
+  itself. A client renders "roll for initiative" from this; it never asks for
+  one.
+
+- **`Dissolve` covers only half of ending a fight.** The party deciding to
+  disengage is a verb. Defeat is a fact the world notices, and when the
+  composition can see it, it arrives as another `DissolveKind` produced
+  automatically — never as a second RPC. The SDK seals its `DissolveCause`
+  interface with an unexported method to make that structural.
+
+## Known gaps, inherited and stated rather than papered over
+
+- **A cold client cannot yet learn its own position from reads.** `GetView`
+  reports what a member perceives and skips self; `GetStatus` carries no member
+  positions. The fix is SDK-first (design rule 11, rpg-toolkit#933) and is
+  explicitly **not** a gate on this package. Until it lands, reconnect leans on
+  `GetStory` replay.
+- **`Attack` is character-attackers-only, and nothing spends.** Both are the
+  SDK's stated scope — a monster's action can declare a save gate the seam has
+  no vocabulary for, and the economy that would spend an action sits above this
+  seam and does not exist. They arrive with the work that calls for them.
+- **No door state or locks.** Fork-independent gap, arriving with its own
+  capability work.
+
+## Relationship to the v1alpha2 encounter service
+
+**None, deliberately.** Design rule 9: no path between `SessionService` and the
+old encounter stack — the two never call, import, or share state. That is why
+this package mints its own `Position` rather than importing
+`dnd5e.api.v1alpha2.encounter.Position`, which would have created exactly such
+a path into a package the cutover deletes.
+
+The two stacks coexist until cutover, with server configuration selecting which
+one `StartEncounter` creates on — exactly one, never both. At cutover the
+v1alpha2 encounter package is removed in place (every consumer moves in the
+same swap), per the versioning trigger in `rpg-project/CLAUDE.md`.
+
+## Status
+
+Proto-only as of this doc. No `rpg-api` handler/orchestrator/repository yet
+(W2 of `rpg-project#227`, the immediate next leg) and no `rpg-dnd5e-web` client
+usage (W3). Not a "live" service by this repo's usual definition — re-grade
+once the rpg-api PR lands.

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -1,7 +1,7 @@
 ---
 name: rpg-api-protos data model
 description: Common message types, envelopes, error and pagination patterns, and known shape collisions
-updated: 2026-05-04
+updated: 2026-08-16
 confidence: high — verified by reading every .proto and grepping field reuse across files
 ---
 
@@ -53,6 +53,27 @@ practice rpg-dnd5e-web only renders these coordinates and rpg-api only
 casts to/from integer cube positions internally. The migration plan is
 in the linked design doc — proto change blocks on the rpg-api types
 landing first.
+
+**There are now three `Position` messages, and the third is deliberate.**
+`api.v1alpha1.Position` and `dnd5e.api.v1alpha2.encounter.Position` are both
+`int32 x/y/z` cube coordinates today (the migration above has landed in the
+proto even though the prose still describes the `double` era). The third,
+`dnd5e.api.session.v1alpha1.Position`, is `double x = 1; double y = 2;` — two
+axes, floating point — because it mirrors the toolkit's `spatial.Position`,
+the one value type the session SDK lets across its boundary. Reusing either
+existing message was considered and rejected in rpg-api-protos#222:
+
+- `api.v1alpha1.Position` would change the type and add an axis the SDK does
+  not have, which is a lossy cast at every boundary and not the
+  field-for-field mirror that session package's contract requires.
+- `dnd5e.api.v1alpha2.encounter.Position` would additionally create an import
+  path from `SessionService` into the package the session cutover deletes,
+  which the session design forbids outright.
+
+This is the one place in the repo where minting a duplicate name beats reuse,
+and it is temporary in the same sense the whole v1alpha2 encounter package is:
+the collision resolves when that package is removed at cutover. See
+[components/session-service.md](components/session-service.md).
 
 ### GridType (`api/v1alpha1/room_common.proto:16`)
 
@@ -261,6 +282,7 @@ Summary table:
 | `DiceRoll` | `api.v1alpha1.DiceRoll` (dice.proto:49, result) AND `dnd5e.api.v1alpha1.DiceRoll` (common.proto:45, notation) | Both live, different roles, same name |
 | `ValidationResult` | `dnd5e.api.v1alpha1.ValidationResult` (common.proto:122, three-tier) | `api.v1alpha1.ValidationResult` (room_common.proto:216, generic, unused) |
 | `Wall` | `api.v1alpha1.Wall` (room_common.proto:104) | `sandbox.api.v1alpha1.WallSegment` — different shape, unused |
+| `Position` | `api.v1alpha1.Position` and `dnd5e.api.v1alpha2.encounter.Position` (both `int32` cube) | `dnd5e.api.session.v1alpha1.Position` (`double x/y`) — a third live shape, mirroring `spatial.Position`; see the Position section above for why reuse was rejected |
 
 Most collisions resolve naturally when the unused services / sandbox
 package are deleted (issue #140). The `DiceRoll` collision survives —
@@ -287,6 +309,10 @@ api/v1alpha1/room_selectables.proto  ← imports room_common
 
 sandbox/api/v1alpha1/sandbox_common.proto ← imports api/v1alpha1/room_common.proto
 sandbox/api/v1alpha1/sandbox_room.proto   ← imports sandbox_common, room_common
+
+dnd5e/api/session/v1alpha1/types.proto    ← no imports, leaf
+dnd5e/api/session/v1alpha1/events.proto   ← no imports, leaf
+dnd5e/api/session/v1alpha1/service.proto  ← imports session types, events (in-package only, by design)
 ```
 
 Dependency hygiene is good: no circular imports, leaf files are leaf

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,7 +1,7 @@
 ---
 name: rpg-api-protos architecture overview
 description: Contract layer rules, repo layout, generation pipeline, and current rule violations
-updated: 2026-07-21
+updated: 2026-08-16
 confidence: high — verified by reading every .proto file, buf.yaml, .github/workflows/ci.yml, and grepping consumer references in rpg-api / rpg-dnd5e-web
 ---
 
@@ -50,6 +50,10 @@ rpg-api-protos/
     events.proto                 # LobbyEvent stream — snapshot + membership/presence deltas
   dnd5e/api/authoring/v1alpha1/  # own subpackage; dev-gated dungeon authoring (Dungeon Builder arc, rpg-project#169)
     service.proto                # AuthoringService — PutDungeon; not yet consumed (rpg-api S1 pending)
+  dnd5e/api/session/v1alpha1/    # service-first layout; field-for-field transcription of rpg-toolkit rulebooks/dnd5e/session (API session integration, rpg-project#227)
+    service.proto                # SessionService — 14 RPCs mirroring the SDK verbs; not yet consumed (rpg-api W2 pending)
+    types.proto                  # Position (double x/y, mirrors spatial.Position), Member, CharacterState, Sighting, Atlas*, SaveReport, ...
+    events.proto                 # Event stream — flat per-recipient envelope + EventKind; no snapshot, GetStory is the resync path
   sandbox/api/v1alpha1/
     sandbox_common.proto        # GenerativeRoomConfig, RoomShape, etc. — defined, not consumed
     sandbox_room.proto          # SandboxRoomService — defined, not consumed

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -1,7 +1,7 @@
 ---
 name: rpg-api-protos quality scorecard
 description: Per-service grade with rationale — a graded scorecard the janitor will update over time
-updated: 2026-05-04
+updated: 2026-08-16
 confidence: low-medium — first draft grades from a read-through of every .proto file plus grep against rpg-api / rpg-dnd5e-web; expect Kirk to adjust
 ---
 
@@ -205,6 +205,41 @@ malformed requests (no body exists), in-band `success=false` +
 runtime validation yet, and `field_errors` is honestly
 one-flat-entry-per-failure in v1 (documented, not hidden — the toolkit's
 `dungeonspec.Validate` doesn't return structured field paths today).
+Re-grade once the rpg-api PR lands.
+
+### dnd5e.session.SessionService — A- (provisional)
+
+Landed 2026-08-16 (rpg-api-protos#222), no consumer yet — same "consumer PR
+pending, not speculative" exception as the two above: `rpg-api` (W2) and
+`rpg-dnd5e-web` (W3) are the queued next legs of `rpg-project#227`.
+
+Graded a notch above its two neighbours for a reason that is structural rather
+than stylistic: **it is the only service in the repo whose shape is not a
+judgement call.** It transcribes the toolkit's `rulebooks/dnd5e/session`
+exported surface field-for-field, and that claim was verified by script — 39
+message↔struct pairs compared field-by-field in declaration order, zero
+mismatches — rather than asserted in a review. The usual failure mode for a new
+contract here (rpg-api quietly inventing vocabulary the toolkit does not have,
+which is what the Boundary Rule exists to prevent) is closed by construction,
+and the design doc makes it explicit: a field with no SDK counterpart is a
+design change, not a proto edit.
+
+Other strengths:
+- Service-first layout matching the `encounter`/`lobby` precedent.
+- `Event` is flat and non-polymorphic because the SDK shaped it that way *for*
+  this mapping — no oneof of 26 variants to legend, which is the single biggest
+  readability drag on `EncounterEvent`.
+- Real decisions are recorded where the next reader hits them, not in a PR
+  body: why `Position` is minted rather than reused, why `UNSPECIFIED` and
+  `UNKNOWN` are different values, why `Turn` takes a member and `GetStatus`
+  must never, why `Traverse` is transitional.
+- Known gaps are stated in the proto (self-position on reads, character-only
+  attackers, nothing spends) rather than discovered at runtime.
+
+Held below A by: no runtime validation this shape survives an orchestrator yet;
+`Traverse` is knowingly transitional, so part of the surface is scheduled to be
+removed; and the minted third `Position` is correct here but is still a name
+collision the repo carries until the v1alpha2 encounter package is deleted.
 Re-grade once the rpg-api PR lands.
 
 ## Defined-but-not-consumed services

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,7 +1,7 @@
 ---
 name: rpg-api-protos status
 description: Where we are with the proto contracts — active work, recently landed, paused, known rough edges, per-service confidence
-updated: 2026-07-21
+updated: 2026-08-16
 confidence: medium — seeded from `git log` since 2025-12, open PRs, and grep across rpg-api / rpg-dnd5e-web; needs Kirk's correction pass
 ---
 
@@ -15,6 +15,26 @@ Connect-ES). When a proto change lands here, it ripples to both consumers; when
 shape and consumer drift, it shows up here as a "rough edge."
 
 ## Active work
+
+- **Session contract: `SessionService` v1alpha1 (rpg-api-protos#221, PR #222,
+  W1 of the API session integration, 2026-08-16)** — additive-only, one new
+  package `dnd5e/api/session/v1alpha1/` (`service.proto`/`types.proto`/
+  `events.proto`). A **transcription, not a design**: fourteen RPCs and every
+  message mirror the exported surface of the toolkit's
+  `rulebooks/dnd5e/session` (shapes read from `session/v0.9.0`) field-for-field,
+  verified by script across 39 message↔struct pairs. No `StartSession` and no
+  `Spawn` — creation stays the lobby's, in-process. `Event` mirrors
+  `session.Event` exactly, payload bytes passed through; `StreamEvents` delivers
+  only the subscribing member's own per-recipient projections and rpg-api never
+  filters. See
+  [architecture/components/session-service.md](architecture/components/session-service.md).
+  Proto-only — `rpg-api` (W2: handler + orchestrator + Redis repos + event
+  broker) and `rpg-dnd5e-web` (W3: new game route) are the next legs
+  (design: `rpg-project/ideas/session-api/design.md`, umbrella
+  `rpg-project#227`). **This surface is what eventually replaces the
+  `dnd5e.api.v1alpha2.encounter` package**, which is deleted in place at
+  cutover; until then the two stacks coexist with server config selecting
+  exactly one.
 
 - **Dungeon Builder: authoring contract (rpg-api-protos#200, S0 of the
   Dungeon Builder arc, 2026-07-30)** — additive-only, one PR: `dungeon_key`
@@ -279,6 +299,7 @@ Your read of where we are. See [quality.md](quality.md) for grade + rationale.
 | `dnd5e.CharacterService` | Medium-high — the biggest service by RPC count (~25 RPCs); coherent draft + finalize flow; deprecated proficiency fields still present |
 | `api.DiceService` | High — small (3 RPCs), consumed by rpg-api, well-shaped |
 | `dnd5e.authoring.AuthoringService` | High (contract) / no consumer yet — new (rpg-api-protos#200, 2026-07-30), 1 focused RPC, gate-passed for shape and error-transport clarity; a consumer (rpg-api S1) is queued in the same arc, distinct from the Low-rated services below which have none in flight |
+| `dnd5e.session.SessionService` | High (contract) / no consumer yet — new (rpg-api-protos#222, 2026-08-16). Confidence is unusually cheap here: the shapes were not designed, they were transcribed from a shipped SDK and machine-checked against it, so "is this the right shape?" reduces to a question the toolkit already answered. What is genuinely unverified is the same thing every pre-consumer service has — that it survives contact with an orchestrator (rpg-api W2, queued) |
 | `api.EnvironmentService` | Low — defined, not consumed. Generic room shape duplicates encounter Room |
 | `api.SpatialService` | Low — defined, not consumed |
 | `api.SpawnService` | Low — defined, not consumed |

--- a/tests/placement-facing/go/go.mod
+++ b/tests/placement-facing/go/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0
-	google.golang.org/protobuf v1.36.11
+	google.golang.org/protobuf v1.36.12
 )
 
 require (

--- a/tests/placement-facing/go/go.sum
+++ b/tests/placement-facing/go/go.sum
@@ -34,5 +34,5 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.83.0 h1:JeNZEKJFbQxArAMl+hiytHauacDNqJUllNfmIMmpqnQ=
 google.golang.org/grpc v1.83.0/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
-google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
-google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
+google.golang.org/protobuf v1.36.12 h1:pJOKDDOyeXErUroCihFAd5LQuwXBSpVnKGrj5o/fwxc=
+google.golang.org/protobuf v1.36.12/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=

--- a/tests/regions/go/go.mod
+++ b/tests/regions/go/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0
-	google.golang.org/protobuf v1.36.11
+	google.golang.org/protobuf v1.36.12
 )
 
 require (

--- a/tests/regions/go/go.sum
+++ b/tests/regions/go/go.sum
@@ -34,5 +34,5 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.83.0 h1:JeNZEKJFbQxArAMl+hiytHauacDNqJUllNfmIMmpqnQ=
 google.golang.org/grpc v1.83.0/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
-google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
-google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
+google.golang.org/protobuf v1.36.12 h1:pJOKDDOyeXErUroCihFAd5LQuwXBSpVnKGrj5o/fwxc=
+google.golang.org/protobuf v1.36.12/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=


### PR DESCRIPTION
W1 of the API session integration initiative (rpg-project#227). Design:
`rpg-project/ideas/session-api/design.md` §1–§2.

New, additive proto package `dnd5e/api/session/v1alpha1/` — `service.proto`,
`types.proto`, `events.proto` — transcribing the exported surface of the
toolkit's `rulebooks/dnd5e/session` package. **No existing proto is touched**;
the only other files in the diff are the five docs the repo's
`add-a-new-service` how-to requires (second commit — see below).

**Shapes read from `rulebooks/dnd5e/session/v0.9.0`** (`spatial` at v0.9.1,
which is what that module pins). Pinned deliberately: the workspace checkout
sat on the unmerged `feat/1038-name-attack-beats` branch, and v0.9.0 is the
squash-merged tag of that same work — the package tree at the tag is
byte-identical to what the shapes were read from, so `EVENT_KIND_STRUCK` /
`EVENT_KIND_MISSED` are released vocabulary, not speculation.

## The service

Fourteen RPCs, mirroring the design's verb table one-for-one:

`Join`, `Exit`, `Move`, `Traverse`, `Attack`, `Turn`, `EndTurn`, `Dissolve`,
`End`, `GetStatus`, `GetStory`, `GetView`, `GetAtlas`, and server-streaming
`StreamEvents`.

No `StartSession` and no `Spawn`. Creation is the lobby's, in-process
(design rule 5) — `LobbyService.StartEncounter` re-points internally.
`Traverse` is marked transitional in the proto itself: per design §0 a
doorway crossing is an ordinary `Move` step at the destination, and the RPC
retires when the SDK verb does.

## Field-for-field, checked mechanically

Design rule 1 says messages mirror the SDK's exported input/output types
field-for-field and rpg-api invents no vocabulary. That was verified by
script, not by eye: 39 message↔struct pairs compared field-by-field in
declaration order after snake_casing, **zero mismatches**. Every Go struct
left unmapped is deliberately out of scope — `StartSessionInput/Output` and
`SpawnInput/Output` (rule 5), `MonsterState` (reachable only from
`SpawnOutput`), and `Config` / `Manager` / `SessionData` / `SaveError`
(host-side construction, persistence and error types the SDK's own laws keep
in-process).

Response naming follows the SDK's return shape: where a verb returns a
struct its fields ride directly on the Response (`MoveResponse` *is*
`session.MoveOutput`), and where it returns a slice the Response wraps one
repeated field (`GetStoryResponse.entries`, `GetViewResponse.sightings`).
No Output type is re-wrapped in a single-field envelope.

## EventKind: a proto enum, open by construction

**Choice: a proto3 enum, single field, no parallel raw string.**

The SDK settles the first half itself — `session.EventKind` is a string enum
rather than free-form prose *because* "it maps directly onto a proto enum,"
and it is the field clients branch on.

The second half is the growth requirement, and a proto3 enum already
satisfies it: an unrecognised value is **preserved** on the wire and readable
by the receiver (`EventKind(37)` in generated Go, the raw number in
`@bufbuild/es`) — never dropped, never a parse failure. So a kind the combat
train adds (rpg-toolkit#959) reaches an old client intact and that client's
`seq` accounting keeps working, which is exactly what the SDK's
delivered-not-dropped rule is protecting. Adding a value stays a compatible
change under `buf breaking`.

A parallel `string kind_raw` passthrough was considered and rejected: it has
no SDK counterpart, so under rule 1 adding one is a design change rather than
a transcription — and the enum already carries everything the string would.

`UNSPECIFIED` and `UNKNOWN` are kept distinct, following the house precedent
`HexState` set in the v1alpha2 encounter package: `EVENT_KIND_UNSPECIFIED`
(0) means the producer failed to set a kind and is a defect, while
`EVENT_KIND_UNKNOWN` mirrors the SDK's own `session.EventUnknown` — a beat
*this toolkit version* does not recognise, delivered on purpose so the
recipient still learns its sequence advanced. It sits at 100 to leave the
low block contiguous for real kinds.

The same reasoning transcribes the other four SDK string enums — `ClockKind`,
`GridKind`, `MemberKind`, `DissolveKind`. `Sighting.channel` and
`Sighting.status` stay **strings**, because the SDK leaves them free-form:
promoting them would be rpg-api inventing a closed vocabulary the toolkit has
not committed to, which is rule 1 pointing the other way.

## Position: minted, and why not reused

`spatial.Position` is `{X, Y float64}` — the one value type the session SDK
lets across its boundary, so it is the shape this contract has to match
rather than choose. Both existing candidates were checked and neither fits:

- `api.v1alpha1.Position` is `int32 x/y/z` cube coordinates. Reusing it would
  change the type and add an axis the SDK does not have — not a field-for-field
  mirror, and a lossy cast at every boundary.
- `dnd5e.api.v1alpha2.encounter.Position` is the same int32 cube shape **and**
  lives in the package the cutover deletes (design §5). Importing it would
  create a path between `SessionService` and the old encounter stack, which
  design rule 9 forbids outright.

So `dnd5e.api.session.v1alpha1.Position` is `double x = 1; double y = 2;`,
with the reasoning recorded in `types.proto` where the next reader will hit it.
The **frame is per-field**, matching the SDK: Atlas coordinates are
dungeon-absolute, while a member's placement (`JoinRequest.position`,
`MemberOutcome.position`) is scoped to the room named alongside it. §0's
one-map ruling is the SDK's destination; the protos follow each reshape rather
than pre-declaring it.

## Where mirroring needed a judgement call

Three places, all noted in the proto comments:

1. **`DissolveRequest.cause`** — the SDK models cause as a *sealed interface*
   (`session.DissolveCause`), which has no wire form of its own. It also ships
   the answer: `session.DissolveKind` is documented as that interface's wire
   form. So the request carries `DissolveKind cause = 3`. The one value is
   named `DISSOLVE_KIND_BY_DECISION` after the Go constant
   `DissolveByDecision` rather than after its string value `"decision"` — the
   SDK's identifier and string differ here (they agree everywhere else), and
   transcribing the identifier is the consistent rule.

2. **`StreamEventsRequest`** — the only message with no SDK struct behind it.
   The SDK's `EventStream` is a host-implemented interface, not a verb, so
   there is nothing to mirror; the shape comes from design rule 4, which
   spells it out as `StreamEvents(session, member)`. `member` is the
   **recipient identity**, and the server delivers only events whose
   `Event.recipient` is that member, verbatim as the toolkit projected them.
   rpg-api neither filters nor re-derives visibility — a host that filtered
   would be reimplementing perception, and its first mistake would leak fog of
   war. Noted: unlike `StreamLobby`, the subscriber is a request field rather
   than purely the authenticated identity, because "encounter member" and
   "authenticated player" are not the same vocabulary; servers must still
   verify entitlement.

3. **`GetStatusResponse` / `GetAtlasResponse` inline their struct's fields**
   rather than nesting a `Status` / `Atlas` message. Same rule as every other
   verb here, and it keeps `Status` from becoming a type that outlives the read
   it belongs to. `session.Status` is encounter-wide and never per-member —
   pinned by the SDK, not merely unimplemented — so the comment says so;
   per-member questions go to `Turn`.

Also inherited verbatim rather than papered over: `GetView` cannot yet answer
"where am I" (View skips self — design rule 11 / toolkit#933, explicitly not a
W1 gate), and `Attack` is character-attackers-only with nothing spending yet.
Both are the SDK's stated scope, recorded in the proto so a client author
meets them here instead of at runtime.

## Verification

```
$ buf format -w --disable-symlinks
$ buf lint --disable-symlinks
(no output — clean)
$ buf format --diff --exit-code --disable-symlinks
(no output — clean)
$ buf breaking --disable-symlinks --against 'https://github.com/KirkDiggler/rpg-api-protos.git#branch=main'
(no output — clean; the change is purely additive)
```

Generation and both consumer compiles, matching what CI runs:

```
$ buf generate --disable-symlinks
  -> gen/go/dnd5e/api/session/v1alpha1/{events,service,service_grpc,types}.pb.go
  -> gen/ts/dnd5e/api/session/v1alpha1/{events,service,types}_pb.ts
$ cd gen/go && go mod tidy && go build ./...
COMPILE-GO OK
$ npx tsc --noEmit --project tsconfig.json
TSC OK
```

Per the repo's CLAUDE.md, no bespoke tests were added — generated-protobuf
mechanics are covered by these gates, and there is no project-specific
generator logic here to test.

## Docs (second commit, `2e05446`)

`docs/how-to/add-a-new-service.md:98-109` says plainly that a new service is a
doc change too, and lists five items; Copilot review flagged their absence.
All five are here, in a separate commit so the contract and the docs can be
reviewed — or dropped — independently:

- **`docs/architecture/components/session-service.md`** (new) — follows
  `lobby-service.md`, the closest precedent. Covers the RPC↔SDK-verb table, the
  event spine, the contract edge cases the SDK decided rather than this repo
  (Traverse transitional, Turn member-scoped, Formed as news), the inherited
  gaps, and the deliberate absence of any path to the v1alpha2 encounter stack.
- **`docs/architecture/overview.md`** — repo layout block.
- **`docs/architecture/data-model.md`** — the Position section now explains the
  three-Position situation and why reuse was rejected in both directions, plus
  a collision-table row and the import graph. It also notes in passing that the
  section's `double`→`int32` "upcoming breaking change" has in fact landed —
  flagged rather than rewritten, since that paragraph predates this PR.
- **`docs/status.md`** — active-work entry + per-service confidence row.
- **`docs/quality.md`** — provisional **A-** under "Newly defined, consumer PR
  pending", graded a notch above its neighbours because this service's shape is
  not a judgement call (machine-checked against the SDK), and held below A by
  the absent orchestrator, the knowingly-transitional `Traverse`, and the
  minted third `Position`.

`updated:` frontmatter bumped on all four edited docs.

## CI: the failure that predated this branch, and its fix (third commit, `08a541e`)

The branch opened onto a CI failure at `Verify Placement facing presence`.
Diagnosed rather than assumed, because the obvious suspect was this PR's own
generation:

**It reproduces on unmodified `origin/main` at `8aa4bda`**, using the repo's
own targets (`make generate && make test-placement-facing-presence`), with the
session package not present in the tree at all.

**Generation was not the cause, on every axis checked.** A/B-ing clean `main`
against this branch: both stamp `protoc-gen-go v1.36.12`; both carry identical
`protoimpl.EnforceVersion(20)` / `MaxVersion - 20` floors; **every generated
file the two trees share is byte-identical**; and the new session package pulls
in exactly the same five imports the existing lobby package already does — it
introduces no new dependency.

**The real trigger.** `buf.gen.yaml` requests its remote plugins with *no
version*, so every `buf generate` — local and CI alike — fetches the newest
protoc-gen-go. Its version tracks the protobuf runtime, so v1.36.12 emits code
wanting runtime v1.36.12. `gen/go/go.mod` is gitignored and tidied fresh each
run, so it follows. `tests/placement-facing/go` and `tests/regions/go` are
committed, pin `v1.36.11`, and `replace` onto `gen/go` — and `-mod=readonly`
correctly refuses the mismatch. CI last ran green 2026-08-09, before that
release. Nothing had to change for this to fire; it broke on a clock.

**Fix**: `go mod tidy` in both test modules. `tests/regions/go` carried the
same stale pin and was only green because its step is skipped once the
placement step fails, so fixing one alone would have moved the failure one step
right. Verified locally with both `make` targets before pushing; the run on
`08a541e` is green end to end.

This buys time rather than closing the class — the same break recurs at the
next protobuf release while the plugin stays unpinned. **#223 stays open** for
the durable fix, and now names pinning the plugin in `buf.gen.yaml` as the
option that would make a generator upgrade a reviewed commit instead of a
surprise.

## Follow-up, deliberately not in this PR

The `mocks` Makefile target has a per-service entry list that this package is
not in. Left alone because it is outside the new package and nothing needs it
yet — rpg-api's W2 handlers mock the orchestrator, not the proto client. Worth
a one-liner whenever a consumer wants a generated client mock.

Closes #221

— director agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

