### PR TITLE
fix: re-pin presence-test modules to protobuf v1.36.12

### DIFF
--- a/tests/placement-facing/go/go.mod
+++ b/tests/placement-facing/go/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0
-	google.golang.org/protobuf v1.36.11
+	google.golang.org/protobuf v1.36.12
 )
 
 require (

--- a/tests/placement-facing/go/go.sum
+++ b/tests/placement-facing/go/go.sum
@@ -34,5 +34,5 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.83.0 h1:JeNZEKJFbQxArAMl+hiytHauacDNqJUllNfmIMmpqnQ=
 google.golang.org/grpc v1.83.0/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
-google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
-google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
+google.golang.org/protobuf v1.36.12 h1:pJOKDDOyeXErUroCihFAd5LQuwXBSpVnKGrj5o/fwxc=
+google.golang.org/protobuf v1.36.12/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=

--- a/tests/regions/go/go.mod
+++ b/tests/regions/go/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0
-	google.golang.org/protobuf v1.36.11
+	google.golang.org/protobuf v1.36.12
 )
 
 require (

--- a/tests/regions/go/go.sum
+++ b/tests/regions/go/go.sum
@@ -34,5 +34,5 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.83.0 h1:JeNZEKJFbQxArAMl+hiytHauacDNqJUllNfmIMmpqnQ=
 google.golang.org/grpc v1.83.0/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
-google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
-google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
+google.golang.org/protobuf v1.36.12 h1:pJOKDDOyeXErUroCihFAd5LQuwXBSpVnKGrj5o/fwxc=
+google.golang.org/protobuf v1.36.12/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=


### PR DESCRIPTION
CI has been red on **every** PR in this repo since `google.golang.org/protobuf`
v1.36.12 was published. Two committed test modules pin the previous version and
`replace` onto a module that floats. This re-pins them.

## Not caused by any proto change

Reproduced on **unmodified `origin/main` at `8aa4bda`**, in a fresh detached
worktree with `git status` clean, using the repo's own targets:

```
$ make generate
$ make test-placement-facing-presence
...
cd tests/placement-facing/go && go test -mod=readonly ./...
go: updates to go.mod needed, disabled by -mod=readonly; to update it:
	go mod tidy
make: *** [Makefile:53: test-placement-facing-presence] Error 1
```

Generation was ruled out as a cause on every axis, by A/B-ing generated output
between clean `main` and a feature branch: both stamp `protoc-gen-go v1.36.12`,
both carry identical `protoimpl.EnforceVersion(20)` / `MaxVersion - 20` floors,
and every generated file the two trees share is byte-identical.

## Root cause: an unpinned plugin feeding a floating module feeding a pinned one

1. **`buf.gen.yaml` requests its remote plugins with no version** —
   `remote: buf.build/protocolbuffers/go`, no `:v...`. Every `buf generate`,
   local and CI alike, fetches the newest protoc-gen-go.
2. **protoc-gen-go's version tracks the protobuf runtime**, so plugin v1.36.12
   emits code that wants runtime v1.36.12.
3. **`gen/go/go.mod` is gitignored** and re-`init`'d + `tidy`'d on every run
   (`Makefile:40`, `Makefile:52`; also `docs/how-to/regenerate-sdks.md:22`), so
   it follows the plugin up.
4. **`tests/placement-facing/go` and `tests/regions/go` are committed**, pin
   `v1.36.11`, and `replace` onto `gen/go`. `-mod=readonly` correctly refuses
   the resulting mismatch.

CI last ran green 2026-08-09, before that release. **Nothing in this repository
had to change for the break to happen — it fired on a clock.**

## The fix

`go mod tidy` in both test modules, re-pinning them to the runtime the
generated code now demands. Four files, six lines:

```
 tests/placement-facing/go/go.mod | 2 +-
 tests/placement-facing/go/go.sum | 4 ++--
 tests/regions/go/go.mod          | 2 +-
 tests/regions/go/go.sum          | 4 ++--
```

**Both modules, deliberately.** `tests/regions/go` carries the identical stale
pin and looks green today only because its CI step is *skipped* once the
placement step fails (`Verify region projection parent presence` runs after
`Verify Placement facing presence`). Fixing only the module that visibly failed
would have moved the failure one step to the right and read as a new problem.

## Verified locally, before and after

Before, on this branch at `origin/main` — `make test-placement-facing-presence`
exits 2 with the readonly error above. After:

```
$ make test-placement-facing-presence
cd tests/placement-facing/go && go test -mod=readonly ./...
ok  	github.com/KirkDiggler/rpg-api-protos/tests/placement-facing/go	0.006s
node tests/placement-facing/ts/out/tests/placement-facing/ts/placement_facing.mjs

$ make test-region-projection-presence
cd tests/regions/go && go test -mod=readonly ./...
ok  	github.com/KirkDiggler/rpg-api-protos/tests/regions/go	0.006s
node tests/regions/ts/out/tests/regions/ts/region_projection.mjs
```

Both Go suites pass and both TypeScript harnesses run to completion.
`buf lint`, `buf format --diff --exit-code`, and `buf breaking` are all clean —
this PR touches no `.proto` file.

## Follow-up decision for Kirk — recommended, not implemented here

**This buys time; it does not close the class.** The tidy re-pins to whatever is
newest today, so the same break recurs at the next protobuf release. Three ways
to actually close it, in the order I'd rank them:

1. **Pin the plugin versions in `buf.gen.yaml`** (e.g.
   `remote: buf.build/protocolbuffers/go:v1.36.12`). This attacks the trigger
   rather than the symptom: a generator upgrade becomes a reviewed commit
   instead of something that arrives on its own schedule and reddens every open
   PR. Cheapest of the three, and the only one that makes the upgrade visible.
2. **Commit `gen/go/go.mod`** (drop it from `.gitignore`) so the generated
   module's dependency versions are reviewed rather than re-resolved fresh on
   every CI run. This addresses the real structural asymmetry — a *committed*
   module `replace`-ing onto a *floating* one can never be stably pinned — and
   makes the generated module's deps a reviewable artifact. Larger change:
   `gen/` is currently ignored wholesale and force-pushed to the `generated`
   branch by CI, so it needs a deliberate decision about what belongs in `main`.
3. **Drop `-mod=readonly`** from the two test steps, letting them tidy against
   whatever `gen/go` resolved. Cheapest to type, but it gives up the pin these
   tests presumably wanted in the first place — it converts a loud failure into
   a silent version drift, which is the wrong direction.

I'd take 1 now and 2 when someone is next in `gen/`'s ignore rules. Not doing
either here: this PR should stay the minimal unblock, and both are Kirk's call.

Interim unblock for #223 — the issue STAYS OPEN for the durable fix decision (plugin pin in buf.gen.yaml, ranked options in the issue body).

— director agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)