### PR TITLE
feat(session)!: re-transcribe session v1alpha1 against session/v0.12.0 — one map, no Traverse

### DIFF
--- a/dnd5e/api/session/v1alpha1/events.proto
+++ b/dnd5e/api/session/v1alpha1/events.proto
@@ -12,6 +12,10 @@ option java_package = "com.kirkdiggler.rpg.api.dnd5e.session.v1alpha1";
 // a string enum rather than free-form prose precisely because "it maps directly
 // onto a proto enum", and it is the field clients branch on.
 //
+// Read from session/v0.12.0. The vocabulary is UNCHANGED across v0.9.0 ->
+// v0.12.0 — all 13 kinds survive the one-map reshape, TRAVERSED included (see
+// below).
+//
 // The vocabulary is OPEN TO GROWTH, which is a property of proto3 enums rather
 // than something this file has to build: an unrecognised number is PRESERVED on
 // the wire and readable by the receiver (`EventKind(37)` in Go, the raw number
@@ -37,9 +41,14 @@ enum EventKind {
 
   // A member stepped to a new cell.
   EVENT_KIND_MOVED = 1;
-  // A member crossed a connection into another room. Distinct from MOVED even
-  // though both are one step in absolute space, because a client may want to
-  // narrate a doorway differently from a corridor.
+  // A member's step carried them through a doorway.
+  //
+  // IT OUTLIVED THE VERB. There is no Traverse RPC any more — a walk crosses a
+  // doorway as an ordinary step — but this kind stayed distinct from MOVED
+  // through that reshape, and the SDK is explicit about why: ONE MAP DOES NOT
+  // MEAN ONE NARRATION. A client renders a doorway differently from a corridor,
+  // and the composition still knows which happened; collapsing them would make
+  // a client re-derive it from the geometry.
   EVENT_KIND_TRAVERSED = 2;
   // A member entered the encounter.
   EVENT_KIND_JOINED = 3;

--- a/dnd5e/api/session/v1alpha1/service.proto
+++ b/dnd5e/api/session/v1alpha1/service.proto
@@ -10,7 +10,7 @@ option java_multiple_files = true;
 option java_package = "com.kirkdiggler.rpg.api.dnd5e.session.v1alpha1";
 
 // SessionService is the wire form of the toolkit's `rulebooks/dnd5e/session`
-// package — one verb surface, transcribed (shapes read from session/v0.9.0).
+// package — one verb surface, transcribed (shapes read from session/v0.12.0).
 //
 // Three rules from rpg-project/ideas/session-api/design.md shape every message
 // below, and are worth reading before adding anything to this file:
@@ -25,6 +25,13 @@ option java_package = "com.kirkdiggler.rpg.api.dnd5e.session.v1alpha1";
 //  5. CREATION IS THE LOBBY'S. The SDK's StartSession and Spawn are deliberately
 //     absent from this service: LobbyService.StartEncounter calls them
 //     in-process. There is no creation RPC here, in v1 or after.
+//
+// ONE MAP, AND NO TRAVERSE. Design §0's ruling has arrived in the SDK rather
+// than remaining a destination this contract waits on: v0.10.0 made the Atlas
+// one map, v0.11.0 took rooms off joins, placements and outcomes, and v0.12.0
+// made a walk cross a doorway and retired the Traverse verb. So there is no
+// Traverse RPC here, no room ID anywhere on the seam, and every position is
+// dungeon-absolute. A doorway crossing is an ordinary step of Move.
 //
 // Response naming follows the SDK's return shape: where a verb returns a struct
 // its fields are carried directly on the Response (MoveResponse IS
@@ -46,13 +53,19 @@ option java_package = "com.kirkdiggler.rpg.api.dnd5e.session.v1alpha1";
 // NOT_FOUND if the session, encounter or character is absent; FAILED_PRECONDITION
 // if the encounter has already ended.
 message JoinRequest {
+  // room = 3 named the room to place the member in, until session v0.11.0 made
+  // placement a cell on the map. See Member in types.proto.
+  reserved 3;
+  reserved "room";
+
   string session = 1;
   // The joining player's character ID, which is also the ID they are known by
   // inside the encounter.
   string member = 2;
-  // The room to place them in.
-  string room = 3;
-  // Where within that room.
+  // The cell to place them on, dungeon-absolute — the same coordinates the
+  // Atlas and every other verb speak. Which room owns that cell is worked out
+  // inside the composition: a caller places somebody on the map, not in a
+  // chamber.
   Position position = 4;
 }
 
@@ -112,9 +125,23 @@ message ExitResponse {
 // Validation is complete before the first cell is entered — a path with a gap is
 // rejected whole rather than walked up to the gap, because a caller who
 // mis-computed a route wants none of it rather than an arbitrary prefix.
-// INVALID_ARGUMENT for an empty or broken path, or a bad position;
-// FAILED_PRECONDITION if the member is in a fight (fights have their own turn
-// structure, which this surface does not expose yet) or the encounter is closed.
+// A WALK CROSSES A DOORWAY (session v0.12.0, rpg-toolkit#1048). The far side of
+// a doorway is simply the next cell along, so a crossing is an ordinary step of
+// the same size as any other and needs no separate verb — which is why the
+// Traverse RPC is gone rather than deprecated.
+//
+// ADJACENCY IS NOT PERMISSION, though, and this is the trap worth knowing: two
+// rooms may TOUCH without a door between them, so a pair of cells can be
+// perfectly adjacent and still have nothing to walk through. That case is
+// invisible to a client reading only GetAtlasResponse.cells — it is in
+// `doorways` or it is nowhere. The SDK refuses it with its own sentinel
+// (ErrNoCrossing, "no doorway joins those cells"), kept distinct from a path
+// that is not a walk at all.
+//
+// INVALID_ARGUMENT for an empty or broken path, a bad position, or a cross-room
+// step with no doorway joining it; FAILED_PRECONDITION if the member is in a
+// fight (fights have their own turn structure, which this surface does not
+// expose yet) or the encounter is closed.
 message MoveRequest {
   string session = 1;
   string member = 2;
@@ -143,44 +170,6 @@ message MoveResponse {
   Formed formed = 4;
   SaveReport saved = 5;
   DeliveryReport delivery = 6;
-}
-
-// TraverseRequest moves a member through a connection into the adjoining room.
-//
-// TRANSITIONAL (design §0). Under world anchoring the two endpoint cells are
-// adjacent in absolute space, so a crossing is one ordinary step of the same
-// size as any other — a client rendering the result cannot tell a doorway from a
-// corridor. This RPC exists only while the SDK still exposes the verb, and
-// retires when the absolute-projection convergence retires it. New clients
-// should prefer Move where they can.
-message TraverseRequest {
-  string session = 1;
-  string member = 2;
-  // The connection to cross.
-  string connection = 3;
-}
-
-// TraverseResponse mirrors session.TraverseOutput.
-message TraverseResponse {
-  // The room departed.
-  string from_room = 1;
-  // Where the member stood before crossing.
-  Position from = 2;
-  // The room arrived in.
-  string to_room = 3;
-  // Where the member arrived.
-  Position to = 4;
-  // What changed in each observer's perception, keyed by observer.
-  map<string, Discovery> discovered = 5;
-  // The story sequence of the recorded crossing.
-  uint64 seq = 6;
-  // Present if an ending fired on arrival.
-  Outcome outcome = 7;
-  // Present if walking through the doorway put the crosser in sight of the
-  // other side and a fight started.
-  Formed formed = 8;
-  SaveReport saved = 9;
-  DeliveryReport delivery = 10;
 }
 
 // =============================================================================
@@ -408,9 +397,30 @@ message GetAtlasRequest {
 // CONSTRUCTION TRUTH — unchanged by movement, joins, exits or endings. Fetch it
 // once per encounter and cache it; never per frame.
 message GetAtlasResponse {
-  // Every room's absolute footprint, sorted by room ID.
-  repeated AtlasRoom rooms = 1;
-  // Every connection's absolute endpoint pair, sorted by connection ID.
+  // rooms = 1 held a repeated AtlasRoom — the per-room decomposition — until
+  // session v0.10.0 flattened the Atlas into one map. `doorways` below keeps
+  // tag 2: same name, same type, genuinely unchanged by the reshape.
+  reserved 1;
+  reserved "rooms";
+
+  // The coordinate family the whole map speaks. One value, not one per room.
+  GridKind grid = 3;
+  // Every cell of the map, sorted by coordinate. Occluded cells are included:
+  // occlusion is walkability, not ownership.
+  //
+  // Sorted by coordinate rather than concatenated room by room, so the
+  // flattening does not leak the old grouping back through iteration order — a
+  // map that still came out room-by-room would be the old shape wearing a new
+  // type.
+  repeated Position cells = 4;
+  // The subset of `cells` that blocks line of sight, reported separately so a
+  // host can render them distinctly. Sorted like `cells`.
+  repeated Position occluders = 5;
+  // Every wall and barrier on the map, sorted by endpoint.
+  repeated AtlasBoundary boundaries = 6;
+  // Every crossable cell pair, sorted by connection ID. Route planning needs
+  // this as well as `cells` — see AtlasDoorway on why adjacency is not
+  // permission.
   repeated AtlasDoorway doorways = 2;
 }
 
@@ -454,14 +464,9 @@ service SessionService {
   // member leaving auto-closes the encounter (ExitResponse.closed).
   rpc Exit(ExitRequest) returns (ExitResponse);
 
-  // Move walks a member along a path, one cell at a time. A short walk is an
-  // answer, not an error.
+  // Move walks a member along a path, one cell at a time, crossing doorways as
+  // ordinary steps. A short walk is an answer, not an error.
   rpc Move(MoveRequest) returns (MoveResponse);
-
-  // Traverse crosses a connection. TRANSITIONAL (design §0): at the destination
-  // a doorway crossing is an ordinary Move step, and this RPC retires with the
-  // SDK verb it mirrors.
-  rpc Traverse(TraverseRequest) returns (TraverseResponse);
 
   // Attack swings one member's weapon at another. Character attackers only in
   // v1; nothing spends yet.

--- a/dnd5e/api/session/v1alpha1/service.proto
+++ b/dnd5e/api/session/v1alpha1/service.proto
@@ -130,17 +130,19 @@ message ExitResponse {
 // the same size as any other and needs no separate verb — which is why the
 // Traverse RPC is gone rather than deprecated.
 //
-// ADJACENCY IS NOT PERMISSION, though, and this is the trap worth knowing: two
-// rooms may TOUCH without a door between them, so a pair of cells can be
-// perfectly adjacent and still have nothing to walk through. That case is
-// invisible to a client reading only GetAtlasResponse.cells — it is in
-// `doorways` or it is nowhere. The SDK refuses it with its own sentinel
-// (ErrNoCrossing, "no doorway joins those cells"), kept distinct from a path
-// that is not a walk at all.
+// ADJACENCY IS NOT PERMISSION, though, and this is the trap worth knowing: a
+// pair of cells can be perfectly adjacent and still have nothing to walk
+// through. Two cells are walkable between only if a doorway joins them or they
+// sit in open floor; the composition's internal chambers are what create the
+// gap, but a client never sees those and does not need to — the observable
+// rule is about cells. That case is invisible to a client reading only
+// GetAtlasResponse.cells: the joint is in `doorways` or it is nowhere. The SDK
+// refuses it with its own sentinel (ErrNoCrossing, "no doorway joins those
+// cells"), kept distinct from a path that is not a walk at all.
 //
-// INVALID_ARGUMENT for an empty or broken path, a bad position, or a cross-room
-// step with no doorway joining it; FAILED_PRECONDITION if the member is in a
-// fight (fights have their own turn structure, which this surface does not
+// INVALID_ARGUMENT for an empty or broken path, a bad position, or a step
+// between two cells that nothing joins; FAILED_PRECONDITION if the member is in
+// a fight (fights have their own turn structure, which this surface does not
 // expose yet) or the encounter is closed.
 message MoveRequest {
   string session = 1;

--- a/dnd5e/api/session/v1alpha1/types.proto
+++ b/dnd5e/api/session/v1alpha1/types.proto
@@ -7,7 +7,7 @@ option java_multiple_files = true;
 option java_package = "com.kirkdiggler.rpg.api.dnd5e.session.v1alpha1";
 
 // This package transcribes the exported surface of the toolkit's
-// `rulebooks/dnd5e/session` package (read from session/v0.9.0). Every message
+// `rulebooks/dnd5e/session` package (read from session/v0.12.0). Every message
 // here mirrors an SDK type field-for-field: rpg-api invents no vocabulary, and
 // a field with no SDK counterpart is a design change that goes through
 // rpg-project/ideas/session-api/design.md first (rule 1).
@@ -18,6 +18,14 @@ option java_package = "com.kirkdiggler.rpg.api.dnd5e.session.v1alpha1";
 //     combat, clock, intel or record types.
 //   - Every string enum the SDK owns exists BECAUSE it maps onto a proto enum
 //     (its words). Each one is transcribed as an enum below, not as a string.
+//
+// ONE MAP. Design §0's ruling — "the encounter has rooms but projects the
+// absolute geo of the dungeon so the session package sees it as all one map" —
+// is no longer a destination this contract is waiting on. It ARRIVED across
+// session v0.10.0 (the Atlas became one map), v0.11.0 (joins, placements and
+// outcomes went roomless) and v0.12.0 (a walk crosses a doorway; Traverse
+// retired). Room IDs no longer cross this seam anywhere, and every position on
+// it is dungeon-absolute.
 
 // =============================================================================
 // Enums
@@ -54,13 +62,16 @@ enum DissolveKind {
   DISSOLVE_KIND_BY_DECISION = 1;
 }
 
-// GridKind names a room's coordinate family. Mirrors session.GridKind
+// GridKind names the map's coordinate family. Mirrors session.GridKind
 // ("square" / "hex").
 //
 // The SDK models this as a string rather than mirroring spatial's iota, for the
 // reason it gives: an iota is an in-process enumeration order, not a wire
 // contract, and reordering it upstream would silently reinterpret every stored
 // and transmitted value. A named proto enum has the same property.
+//
+// ONE VALUE FOR THE WHOLE MAP, not one per room (v0.10.0). A field has a single
+// grid family by law, so a per-room grid was the same answer repeated.
 enum GridKind {
   GRID_KIND_UNSPECIFIED = 0;
   // Square grid, where distance is Chebyshev.
@@ -88,6 +99,12 @@ enum MemberKind {
 // the session SDK lets across its boundary, and therefore the one this contract
 // must match rather than choose.
 //
+// EVERY POSITION ON THIS SEAM IS DUNGEON-ABSOLUTE. That is now uniform rather
+// than per-field: as of session v0.11.0 a member's placement is a cell on the
+// map, not a cell within a named room, so the Atlas, JoinRequest, MoveRequest,
+// Member, MemberOutcome and Step all speak the same coordinates. There is no
+// room-local frame left on this contract to get wrong.
+//
 // Minted here rather than reusing an existing Position, deliberately, and both
 // candidates were checked:
 //
@@ -98,12 +115,6 @@ enum MemberKind {
 //     lives in the package the cutover deletes. Importing it would create a
 //     path between SessionService and the old encounter stack, which rule 9
 //     forbids outright.
-//
-// The FRAME is per-field, not global, because the SDK's is: Atlas coordinates
-// are dungeon-absolute, while a member's placement (JoinRequest.position,
-// MemberOutcome.position) is scoped to the room named alongside it. Design §0's
-// ruling — the session package speaks one map — is the destination the SDK
-// converges on; the protos follow each reshape rather than pre-declaring it.
 message Position {
   double x = 1;
   double y = 2;
@@ -113,22 +124,35 @@ message Position {
 // Roster
 // =============================================================================
 
-// Member is one participant's placement in the encounter. Mirrors
-// session.Member.
+// Member is one participant's placement on the map. Mirrors session.Member.
 message Member {
+  // room = 3 held a room ID until session v0.11.0 took rooms off this seam.
+  // Retired rather than retyped in place: reusing a tag for a different type is
+  // the one proto change that fails silently.
+  reserved 3;
+  reserved "room";
+
   string id = 1;
   MemberKind kind = 2;
-  // The room the member currently occupies.
-  string room = 3;
+  // The cell they stand on, dungeon-absolute.
+  //
+  // This replaced a room ID in session v0.11.0, and the SDK calls that swap the
+  // reshape in one field: which chamber somebody is in is the composition's own
+  // decomposition, while where they STAND is the thing a client renders, a rule
+  // measures, and another member walks toward.
+  Position position = 4;
 }
 
 // MemberOutcome is where a member stood when something closed around them.
 // Mirrors session.MemberOutcome.
 message MemberOutcome {
+  // room = 2 held a room ID until session v0.11.0. See Member.
+  reserved 2;
+  reserved "room";
+
   string id = 1;
-  // The room they were in.
-  string room = 2;
-  // Where they stood within it.
+  // Where they stood when it ended, dungeon-absolute — the same frame every
+  // other position on this seam speaks. Keeps the tag it has always had.
   Position position = 3;
 }
 
@@ -240,7 +264,7 @@ message Outcome {
 // wherever sight changes and starts the fight itself, and whichever verb caused
 // it carries the report back. A client renders "roll for initiative" from this;
 // it never asks for one. That is why it appears on every verb that can put two
-// sides in sight of each other — a walk, a doorway, an arrival.
+// sides in sight of each other — a walk or an arrival.
 message Formed {
   // The fight's initiative order, first to act first.
   repeated string order = 1;
@@ -309,7 +333,7 @@ message StoryEntry {
 }
 
 // =============================================================================
-// Atlas — the static world map
+// Atlas — the static world map, in one piece
 // =============================================================================
 
 // AtlasBoundary is one wall or barrier crossing between adjacent cells. Mirrors
@@ -323,37 +347,30 @@ message AtlasBoundary {
   bool blocks_line_of_sight = 4;
 }
 
-// AtlasRoom is one room's absolute-space footprint. Mirrors session.AtlasRoom.
-message AtlasRoom {
-  string id = 1;
-  GridKind grid = 2;
-  // The room's dungeon-absolute anchor.
-  Position origin = 3;
-  int32 width = 4;
-  int32 height = 5;
-  // Every cell of the room in dungeon-absolute space, occluded cells included:
-  // occlusion is walkability, not ownership.
-  repeated Position cells = 6;
-  // The subset of `cells` that blocks line of sight, reported separately so a
-  // host can render them distinctly.
-  repeated Position occluders = 7;
-  repeated AtlasBoundary boundaries = 8;
-}
-
-// AtlasDoorway is one connection's absolute endpoint pair. Mirrors
-// session.AtlasDoorway.
+// AtlasDoorway is one crossable cell pair. Mirrors session.AtlasDoorway.
 //
-// The two cells are adjacent in absolute space, so crossing one is an ordinary
-// step — which is design §0's ruling visible in the SDK's own shapes, and the
-// reason Traverse is transitional.
+// TWO CELLS, NOT TWO ROOMS. Before session v0.10.0 this named a source room, a
+// destination room and a cell in each; now it is a connection ID and the two
+// adjacent absolute cells it joins. That is the one-map reshape at its sharpest
+// — the far side of a doorway is simply the next cell along.
+//
+// It is also load-bearing for movement rather than decorative: ADJACENCY IS NOT
+// PERMISSION. Two rooms may touch without a door between them, so a pair of
+// cells can be perfectly adjacent and still have nothing to walk through. A
+// client planning a route must consult this list, not just `cells` — a
+// cross-room step with no doorway is refused with the SDK's ErrNoCrossing.
 message AtlasDoorway {
+  // 2..5 were from/from_cell/to/to_cell — a room-pair plus a cell in each —
+  // until session v0.10.0 made a doorway two absolute cells. `from` and `to`
+  // come back below at fresh tags with a new type, so their NAMES are reused
+  // and cannot be reserved; the retired tags are, and so are the two names that
+  // do not come back.
+  reserved 2, 3, 4, 5;
+  reserved "from_cell", "to_cell";
+
   string connection = 1;
-  // The source room ID.
-  string from = 2;
-  // The endpoint in `from`, dungeon-absolute.
-  Position from_cell = 3;
-  // The destination room ID.
-  string to = 4;
-  // The endpoint in `to`, dungeon-absolute.
-  Position to_cell = 5;
+  // One of the two cells, dungeon-absolute.
+  Position from = 6;
+  // The other, adjacent to `from`.
+  Position to = 7;
 }

--- a/dnd5e/api/session/v1alpha1/types.proto
+++ b/dnd5e/api/session/v1alpha1/types.proto
@@ -355,10 +355,10 @@ message AtlasBoundary {
 // — the far side of a doorway is simply the next cell along.
 //
 // It is also load-bearing for movement rather than decorative: ADJACENCY IS NOT
-// PERMISSION. Two rooms may touch without a door between them, so a pair of
-// cells can be perfectly adjacent and still have nothing to walk through. A
-// client planning a route must consult this list, not just `cells` — a
-// cross-room step with no doorway is refused with the SDK's ErrNoCrossing.
+// PERMISSION. A pair of cells can be perfectly adjacent and still have nothing
+// to walk through. A client planning a route must consult this list and not
+// just `cells` — a step between two cells that no doorway joins is refused with
+// the SDK's ErrNoCrossing.
 message AtlasDoorway {
   // 2..5 were from/from_cell/to/to_cell — a room-pair plus a cell in each —
   // until session v0.10.0 made a doorway two absolute cells. `from` and `to`

--- a/docs/architecture/components/session-service.md
+++ b/docs/architecture/components/session-service.md
@@ -1,8 +1,8 @@
 ---
 name: SessionService
-description: D&D 5e session contract (v1alpha1) — the wire transcription of the toolkit's session package; the surface that replaces the v1alpha2 encounter stack
+description: D&D 5e session contract (v1alpha1) — the wire transcription of the toolkit's session package; one map, no rooms on the seam; the surface that replaces the v1alpha2 encounter stack
 updated: 2026-08-16
-confidence: high — proto-side only; no consumer yet, verified by scripted field-for-field comparison against rulebooks/dnd5e/session v0.9.0
+confidence: high — proto-side only; no consumer yet, verified by scripted field-for-field comparison against rulebooks/dnd5e/session v0.12.0 read from the tag
 ---
 
 # SessionService
@@ -13,8 +13,9 @@ Defined in `dnd5e/api/session/v1alpha1/` (service-first layout:
 Package `dnd5e.api.session.v1alpha1`.
 
 Design doc: `rpg-project/ideas/session-api/design.md`. Umbrella:
-`KirkDiggler/rpg-project#227`. Landed by rpg-api-protos#222 (issue #221) as W1
-of that initiative.
+`KirkDiggler/rpg-project#227`. Landed by rpg-api-protos#222 (issue #221) against
+session/v0.9.0, then re-transcribed by #226 (issue #225) against
+**session/v0.12.0**, which is the version this doc describes.
 
 ## What makes this service different from every other one here
 
@@ -42,16 +43,38 @@ repo, and each apparent oddity is the SDK's, faithfully carried:
   Promoting them to enums would be inventing a closed vocabulary the toolkit
   has not committed to.
 
+## One map — the ruling arrived
+
+Design §0 recorded Kirk's ruling that *"the encounter has rooms but projects
+the absolute geo of the dungeon so the session package sees it as all one
+map."* When #222 landed, that was still the seam's **destination**, and the
+contract carried room IDs plus a transitional `Traverse` RPC. It is now the
+seam's **state**, delivered across three toolkit releases:
+
+| release | what changed |
+|---|---|
+| `session/v0.10.0` | the Atlas became one map — no per-room decomposition, one grid for the field, cells sorted by coordinate |
+| `session/v0.11.0` | joins, placements and outcomes went roomless — `Member` trades its room ID for an absolute `position` |
+| `session/v0.12.0` | a walk crosses a doorway; the `Traverse` verb retires |
+
+Consequences for this contract, all live:
+
+- **No `Traverse` RPC.** It is gone, not deprecated — there is no SDK verb
+  behind it. A doorway crossing is an ordinary step of `Move`.
+- **No room ID anywhere on the seam.** `JoinRequest`, `Member`,
+  `MemberOutcome` and `AtlasDoorway` all speak cells.
+- **Every position is dungeon-absolute**, uniformly. There is no room-local
+  frame left on this contract to get wrong.
+
 ## RPCs
 
-Fourteen, mirroring the SDK verbs one-for-one.
+Thirteen, mirroring the SDK verbs one-for-one.
 
 | RPC | SDK verb | Request:Response | Notes |
 |---|---|---|---|
-| `Join` | `Join` | `JoinRequest:JoinResponse` | Players only. Character is loaded before placement, so a member with no loadable sheet never joins |
+| `Join` | `Join` | `JoinRequest:JoinResponse` | Players only. Takes an absolute cell — a caller places somebody on the map, not in a chamber |
 | `Exit` | `Exit` | `ExitRequest:ExitResponse` | Returns the knowledge that leaves with the member (`carry`); last member out auto-closes the encounter (`closed`) |
-| `Move` | `Move` | `MoveRequest:MoveResponse` | A **path**, not a destination. Fewer `steps` than requested `path` is an answer, not an error — the reason is in `outcome` or `formed` |
-| `Traverse` | `Traverse` | `TraverseRequest:TraverseResponse` | **Transitional.** See below |
+| `Move` | `Move` | `MoveRequest:MoveResponse` | A **path**, not a destination; crosses doorways as ordinary steps. Fewer `steps` than requested `path` is an answer, not an error |
 | `Attack` | `Attack` | `AttackRequest:AttackResponse` | Character attackers only in v1; nothing spends yet |
 | `Turn` | `Turn` | `TurnRequest:TurnResponse` | Asked of a **member**, never of the session. See below |
 | `EndTurn` | `EndTurn` | `EndTurnRequest:EndTurnResponse` | No "end the current turn" form, for the same reason `Turn` takes a member |
@@ -65,15 +88,45 @@ Fourteen, mirroring the SDK verbs one-for-one.
 
 **No `StartSession` and no `Spawn`**, though the SDK exposes both. Creation is
 the lobby's: `LobbyService.StartEncounter` calls them in-process (design rule
-5). There is no creation RPC on this service in v1 or after.
+5). There is no creation RPC here, in v1 or after.
+
+## Movement, and the trap in it
+
+A walk crosses a doorway because the far side of a doorway is simply the next
+cell along. That is what made `Traverse` unnecessary.
+
+But **adjacency is not permission**, and this is the part worth knowing before
+writing a client. Two rooms may *touch* without a door between them, so a pair
+of cells can be perfectly adjacent and still have nothing to walk through. That
+case is invisible to a client reading only `GetAtlasResponse.cells` — it is in
+`doorways` or it is nowhere. A route planner must consult both.
+
+The SDK gives that refusal its own sentinel (`ErrNoCrossing`, *"no doorway
+joins those cells"*), kept deliberately distinct from `ErrBrokenPath` (the two
+cells are not adjacent at all) and `ErrBadPosition` (there is no cell there).
+Three different author mistakes, three different places to look.
+
+## The Atlas
+
+`GetAtlasResponse` is the whole map in one piece: one `grid` for the field,
+every `cell` sorted by coordinate, the `occluders` subset that blocks sight,
+every `boundary`, and every `doorway` as a crossable cell pair.
+
+The sort order is load-bearing rather than cosmetic — the SDK sorts by
+coordinate specifically so the flattening does not leak the old room grouping
+back through iteration order. A map that still came out room-by-room would be
+the old shape wearing a new type.
+
+Construction truth: unchanged by movement, joins, exits or endings. Fetch it
+once per encounter and cache it; never per frame.
 
 ## The event spine
 
 `Event` (`events.proto`) mirrors `session.Event` exactly — `session`, `seq`,
 `at`, `correlation`, `recipient`, `kind`, `payload`. The SDK's own godoc says
 it was shaped flat and non-polymorphic *for this mapping*: no interface-valued
-fields, no type switches on the wire, no payload shape that varies by kind in
-a way a generated client cannot express.
+fields, no type switches on the wire, and no payload shape that varies by kind
+in a way a generated client cannot express.
 
 Three properties worth holding onto:
 
@@ -90,10 +143,11 @@ Three properties worth holding onto:
   obligation, which is why there is no snapshot-then-deltas pattern here — the
   shape `StreamEncounter` and `StreamLobby` both use.
 
-`EventKind` is a proto enum with 13 named values plus `UNSPECIFIED`. It is
-**open to growth by construction**: proto3 preserves an unrecognised enum
-number rather than dropping it, so a kind added later (rpg-toolkit#959) reaches
-an old client intact and that client's `seq` accounting keeps working.
+`EventKind` is a proto enum with 13 named values plus `UNSPECIFIED`, and the
+vocabulary is **unchanged from v0.9.0 through v0.12.0**. It is **open to growth
+by construction**: proto3 preserves an unrecognised enum number rather than
+dropping it, so a kind added later (rpg-toolkit#959) reaches an old client
+intact and that client's `seq` accounting keeps working.
 
 `EVENT_KIND_UNSPECIFIED` (0) and `EVENT_KIND_UNKNOWN` (100) are deliberately
 different: 0 means the producer failed to set a kind (a defect), while
@@ -102,14 +156,14 @@ version* does not recognise, delivered on purpose so the recipient still learns
 its sequence advanced. Same distinction `HexState` draws in the v1alpha2
 encounter package.
 
-## Contract edge cases (decided by the SDK, transcribed rather than re-decided)
+**`EVENT_KIND_TRAVERSED` outlived the verb it was named for.** There is no
+Traverse RPC any more, but the kind stayed distinct from `MOVED` through the
+reshape, and the SDK is explicit about why: *one map does not mean one
+narration.* A client renders a doorway differently from a corridor, and the
+composition still knows which happened; collapsing them would make a client
+re-derive it from the geometry.
 
-- **`Traverse` is transitional.** Per design §0, Kirk's ruling is that the
-  encounter has rooms but projects dungeon-absolute geometry, so the session
-  package sees one map. At that destination a doorway crossing is an ordinary
-  `Move` step, and a client cannot tell a doorway from a corridor. The RPC
-  exists while the SDK exposes the verb and retires when the SDK's
-  absolute-projection convergence retires it. New clients should prefer `Move`.
+## Contract edge cases (decided by the SDK, transcribed rather than re-decided)
 
 - **`Turn` is asked of a member, never of the session.** Several clocks can run
   at once — a fight in the crypt while the rest of the party explores the hall
@@ -124,10 +178,9 @@ encounter package.
   single-player included. This is why the stream is not optional.
 
 - **`Formed` appears on every verb that can put two sides in sight of each
-  other** (`Join`, `Move`, `Traverse`). A fight is *news*, not a decision: the
-  composition detects contact wherever sight changes and starts the fight
-  itself. A client renders "roll for initiative" from this; it never asks for
-  one.
+  other** (`Join`, `Move`). A fight is *news*, not a decision: the composition
+  detects contact wherever sight changes and starts the fight itself. A client
+  renders "roll for initiative" from this; it never asks for one.
 
 - **`Dissolve` covers only half of ending a fight.** The party deciding to
   disengage is a verb. Defeat is a fact the world notices, and when the
@@ -137,17 +190,20 @@ encounter package.
 
 ## Known gaps, inherited and stated rather than papered over
 
-- **A cold client cannot yet learn its own position from reads.** `GetView`
-  reports what a member perceives and skips self; `GetStatus` carries no member
-  positions. The fix is SDK-first (design rule 11, rpg-toolkit#933) and is
-  explicitly **not** a gate on this package. Until it lands, reconnect leans on
-  `GetStory` replay.
+- **A cold client still cannot learn its own position from a read.** This
+  narrowed at v0.11.0 without closing: `Member` now carries an absolute
+  `position`, so a `Join` tells you where you are — but no *read* returns a
+  `Member`. `GetView` reports what a member perceives and skips self;
+  `GetStatus` is encounter-wide. So a client that reconnects still leans on
+  `GetStory` replay. The fix is SDK-first (design rule 11, rpg-toolkit#933) and
+  is explicitly not a gate on this package.
 - **`Attack` is character-attackers-only, and nothing spends.** Both are the
   SDK's stated scope — a monster's action can declare a save gate the seam has
   no vocabulary for, and the economy that would spend an action sits above this
   seam and does not exist. They arrive with the work that calls for them.
-- **No door state or locks.** Fork-independent gap, arriving with its own
-  capability work.
+- **No door state or locks.** A doorway is crossable or absent; there is no
+  closed/locked state on the wire yet. Fork-independent gap, arriving with its
+  own capability work.
 
 ## Relationship to the v1alpha2 encounter service
 
@@ -164,7 +220,8 @@ same swap), per the versioning trigger in `rpg-project/CLAUDE.md`.
 
 ## Status
 
-Proto-only as of this doc. No `rpg-api` handler/orchestrator/repository yet
-(W2 of `rpg-project#227`, the immediate next leg) and no `rpg-dnd5e-web` client
-usage (W3). Not a "live" service by this repo's usual definition — re-grade
-once the rpg-api PR lands.
+Proto-only as of this doc. rpg-api's implementation (W2 of `rpg-project#227`)
+is in flight and was written against the v0.9.0 shapes, so it absorbs this
+reshape — the Traverse handler goes away and placements become cells. No
+`rpg-dnd5e-web` client usage yet (W3). Not a "live" service by this repo's
+usual definition — re-grade once the rpg-api PR lands.

--- a/docs/architecture/components/session-service.md
+++ b/docs/architecture/components/session-service.md
@@ -96,10 +96,12 @@ A walk crosses a doorway because the far side of a doorway is simply the next
 cell along. That is what made `Traverse` unnecessary.
 
 But **adjacency is not permission**, and this is the part worth knowing before
-writing a client. Two rooms may *touch* without a door between them, so a pair
-of cells can be perfectly adjacent and still have nothing to walk through. That
-case is invisible to a client reading only `GetAtlasResponse.cells` — it is in
-`doorways` or it is nowhere. A route planner must consult both.
+writing a client. A pair of cells can be perfectly adjacent and still have
+nothing to walk through. The composition's internal chambers are what create
+those gaps, but a client never sees chambers and does not need to — the
+observable rule is entirely about cells: the joint is in
+`GetAtlasResponse.doorways` or it is nowhere. A route planner must consult that
+list as well as `cells`.
 
 The SDK gives that refusal its own sentinel (`ErrNoCrossing`, *"no doorway
 joins those cells"*), kept deliberately distinct from `ErrBrokenPath` (the two

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -75,6 +75,15 @@ and it is temporary in the same sense the whole v1alpha2 encounter package is:
 the collision resolves when that package is removed at cutover. See
 [components/session-service.md](components/session-service.md).
 
+**Frame: uniformly dungeon-absolute** (updated for session/v0.12.0). The first
+cut of this package carried a *per-field* frame — the Atlas was absolute while a
+member's placement was scoped to a room named alongside it — because the SDK's
+was. That is gone. Across session v0.10.0-v0.12.0 the seam became one map: room
+IDs no longer cross it anywhere, and `JoinRequest`, `MoveRequest`, `Member`,
+`MemberOutcome`, `Step`, `AtlasDoorway` and `AtlasBoundary` all speak the same
+absolute coordinates. There is no room-local frame left in this package to
+confuse with an absolute one.
+
 ### GridType (`api/v1alpha1/room_common.proto:16`)
 
 ```proto

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -50,9 +50,9 @@ rpg-api-protos/
     events.proto                 # LobbyEvent stream — snapshot + membership/presence deltas
   dnd5e/api/authoring/v1alpha1/  # own subpackage; dev-gated dungeon authoring (Dungeon Builder arc, rpg-project#169)
     service.proto                # AuthoringService — PutDungeon; not yet consumed (rpg-api S1 pending)
-  dnd5e/api/session/v1alpha1/    # service-first layout; field-for-field transcription of rpg-toolkit rulebooks/dnd5e/session (API session integration, rpg-project#227)
-    service.proto                # SessionService — 14 RPCs mirroring the SDK verbs; not yet consumed (rpg-api W2 pending)
-    types.proto                  # Position (double x/y, mirrors spatial.Position), Member, CharacterState, Sighting, Atlas*, SaveReport, ...
+  dnd5e/api/session/v1alpha1/    # service-first layout; field-for-field transcription of rpg-toolkit rulebooks/dnd5e/session @ v0.12.0 — one map, no room IDs on the seam (rpg-project#227)
+    service.proto                # SessionService — 13 RPCs mirroring the SDK verbs (no Traverse: a walk crosses a doorway); not yet consumed (rpg-api W2 in flight)
+    types.proto                  # Position (double x/y, mirrors spatial.Position), Member, CharacterState, Sighting, AtlasDoorway/Boundary, SaveReport, ...
     events.proto                 # Event stream — flat per-recipient envelope + EventKind; no snapshot, GetStory is the resync path
   sandbox/api/v1alpha1/
     sandbox_common.proto        # GenerativeRoomConfig, RoomShape, etc. — defined, not consumed

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -209,7 +209,10 @@ Re-grade once the rpg-api PR lands.
 
 ### dnd5e.session.SessionService — A- (provisional)
 
-Landed 2026-08-16 (rpg-api-protos#222), no consumer yet — same "consumer PR
+Landed 2026-08-16 (rpg-api-protos#222) against `session/v0.9.0`, re-transcribed
+the same day against `session/v0.12.0` (#226, issue #225) after Kirk ruled the
+contract should track the latest SDK rather than the version it was first
+written from. No consumer yet — same "consumer PR
 pending, not speculative" exception as the two above: `rpg-api` (W2) and
 `rpg-dnd5e-web` (W3) are the queued next legs of `rpg-project#227`.
 
@@ -232,13 +235,25 @@ Other strengths:
 - Real decisions are recorded where the next reader hits them, not in a PR
   body: why `Position` is minted rather than reused, why `UNSPECIFIED` and
   `UNKNOWN` are different values, why `Turn` takes a member and `GetStatus`
-  must never, why `Traverse` is transitional.
+  must never, and why a walk crosses a doorway while adjacency is still not
+  permission.
 - Known gaps are stated in the proto (self-position on reads, character-only
   attackers, nothing spends) rather than discovered at runtime.
 
-Held below A by: no runtime validation this shape survives an orchestrator yet;
-`Traverse` is knowingly transitional, so part of the surface is scheduled to be
-removed; and the minted third `Position` is correct here but is still a name
+**The v0.12.0 pass removed one of the three things holding it below A.**
+`Traverse` was called out here as knowingly transitional — part of the surface
+scheduled for removal. It is now removed rather than scheduled: the SDK retired
+the verb, a walk crosses a doorway, and the contract followed the same day. The
+same pass took room IDs off the seam entirely, so the per-field coordinate frame
+(absolute in the Atlas, room-scoped in placements) that a client could plausibly
+have confused is gone too.
+
+That re-transcription is also the first evidence this contract tracks its source
+rather than drifting from it, which is the property the whole transcription
+argument rests on.
+
+Still held below A by: no runtime validation this shape survives an orchestrator
+yet, and the minted third `Position`, which is correct here but is still a name
 collision the repo carries until the v1alpha2 encounter package is deleted.
 Re-grade once the rpg-api PR lands.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,7 +17,8 @@ shape and consumer drift, it shows up here as a "rough edge."
 ## Active work
 
 - **Session contract re-transcribed against `session/v0.12.0`
-  (rpg-api-protos#225, W1 of the API session integration, 2026-08-16)** — the
+  (rpg-api-protos#226, issue #225, W1 of the API session integration,
+  2026-08-16)** — the
   one-map contract. #222 landed `dnd5e/api/session/v1alpha1/` against
   `session/v0.9.0`; #226 re-transcribes it in place against `session/v0.12.0`
   after Kirk's ruling (*"we should be going off the latest session version.

--- a/docs/status.md
+++ b/docs/status.md
@@ -16,22 +16,24 @@ shape and consumer drift, it shows up here as a "rough edge."
 
 ## Active work
 
-- **Session contract: `SessionService` v1alpha1 (rpg-api-protos#221, PR #222,
-  W1 of the API session integration, 2026-08-16)** — additive-only, one new
-  package `dnd5e/api/session/v1alpha1/` (`service.proto`/`types.proto`/
-  `events.proto`). A **transcription, not a design**: fourteen RPCs and every
-  message mirror the exported surface of the toolkit's
-  `rulebooks/dnd5e/session` (shapes read from `session/v0.9.0`) field-for-field,
-  verified by script across 39 message↔struct pairs. No `StartSession` and no
-  `Spawn` — creation stays the lobby's, in-process. `Event` mirrors
-  `session.Event` exactly, payload bytes passed through; `StreamEvents` delivers
-  only the subscribing member's own per-recipient projections and rpg-api never
-  filters. See
+- **Session contract re-transcribed against `session/v0.12.0`
+  (rpg-api-protos#225, W1 of the API session integration, 2026-08-16)** — the
+  one-map contract. #222 landed `dnd5e/api/session/v1alpha1/` against
+  `session/v0.9.0`; #226 re-transcribes it in place against `session/v0.12.0`
+  after Kirk's ruling (*"we should be going off the latest session version.
+  traverse is dead... let's get the contract we want not one that matches"*).
+  **Breaking by design**, carried on the `breaking-change-approved` label: the
+  `Traverse` RPC and its messages are gone (a walk crosses a doorway —
+  toolkit#1048/#1049), `AtlasRoom` is gone (the Atlas is one map — v0.10.0), and
+  `Member`/`MemberOutcome`/`JoinRequest` are roomless, trading room IDs for
+  absolute cells (v0.11.0). Every position on the seam is now dungeon-absolute.
+  13 RPCs. Verified field-for-field against the **tag**, not a checkout tree —
+  37 message-struct pairs, zero mismatches. See
   [architecture/components/session-service.md](architecture/components/session-service.md).
-  Proto-only — `rpg-api` (W2: handler + orchestrator + Redis repos + event
-  broker) and `rpg-dnd5e-web` (W3: new game route) are the next legs
-  (design: `rpg-project/ideas/session-api/design.md`, umbrella
-  `rpg-project#227`). **This surface is what eventually replaces the
+  Proto-only — `rpg-api` (W2, in flight against the v0.9.0 shapes, absorbs this
+  reshape) and `rpg-dnd5e-web` (W3) are the next legs (design:
+  `rpg-project/ideas/session-api/design.md`, umbrella `rpg-project#227`).
+  **This surface is what eventually replaces the
   `dnd5e.api.v1alpha2.encounter` package**, which is deleted in place at
   cutover; until then the two stacks coexist with server config selecting
   exactly one.
@@ -299,7 +301,7 @@ Your read of where we are. See [quality.md](quality.md) for grade + rationale.
 | `dnd5e.CharacterService` | Medium-high — the biggest service by RPC count (~25 RPCs); coherent draft + finalize flow; deprecated proficiency fields still present |
 | `api.DiceService` | High — small (3 RPCs), consumed by rpg-api, well-shaped |
 | `dnd5e.authoring.AuthoringService` | High (contract) / no consumer yet — new (rpg-api-protos#200, 2026-07-30), 1 focused RPC, gate-passed for shape and error-transport clarity; a consumer (rpg-api S1) is queued in the same arc, distinct from the Low-rated services below which have none in flight |
-| `dnd5e.session.SessionService` | High (contract) / no consumer yet — new (rpg-api-protos#222, 2026-08-16). Confidence is unusually cheap here: the shapes were not designed, they were transcribed from a shipped SDK and machine-checked against it, so "is this the right shape?" reduces to a question the toolkit already answered. What is genuinely unverified is the same thing every pre-consumer service has — that it survives contact with an orchestrator (rpg-api W2, queued) |
+| `dnd5e.session.SessionService` | High (contract) / no consumer yet — new (rpg-api-protos#222, re-transcribed against session/v0.12.0 in #226, 2026-08-16). Confidence is unusually cheap here: the shapes were not designed, they were transcribed from a shipped SDK and machine-checked against it, so "is this the right shape?" reduces to a question the toolkit already answered. What is genuinely unverified is the same thing every pre-consumer service has — that it survives contact with an orchestrator (rpg-api W2, queued) |
 | `api.EnvironmentService` | Low — defined, not consumed. Generic room shape duplicates encounter Room |
 | `api.SpatialService` | Low — defined, not consumed |
 | `api.SpawnService` | Low — defined, not consumed |


### PR DESCRIPTION
Re-transcribes `dnd5e/api/session/v1alpha1` in place against
**`rulebooks/dnd5e/session/v0.12.0`**. W1 of the API session integration
(rpg-project#227); design: `rpg-project/ideas/session-api/design.md` §0–§2.

#222 transcribed this package against `session/v0.9.0` and shipped a
`Traverse` RPC marked transitional. Kirk's ruling the same day: *"we should be
going off the latest session version. traverse is dead... this is just coming
online so let's get the contract we want not one that matches."*

## Design §0 stopped being a destination

§0 recorded the ruling that the session package "sees it as all one map," and
#222 treated that as where the SDK was heading. It has arrived, across three
releases:

| release | what changed |
|---|---|
| `session/v0.10.0` | the Atlas became one map — no per-room decomposition, one grid for the field, cells sorted by coordinate |
| `session/v0.11.0` | joins, placements and outcomes went roomless — `Member` trades its room ID for an absolute `position` |
| `session/v0.12.0` | a walk crosses a doorway; the `Traverse` verb retires (toolkit#1048 / #1049) |

So this is not "remove one RPC." Room IDs no longer cross the seam anywhere,
and every position on it is dungeon-absolute.

## The v0.9.0 → v0.12.0 surface diff, in full

Computed by diffing `go doc -all` output between two **detached worktrees at
the two tags** — not from any checkout tree (see Provenance below).

**Removed types (3):** `AtlasRoom`, `TraverseInput`, `TraverseOutput`
**Added types:** none
**Verbs:** `Traverse` removed; nothing added. 14 RPCs → **13**.

**Reshaped:**

| type | change |
|---|---|
| `Atlas` | `Rooms []AtlasRoom` → `Grid`, `Cells`, `Occluders`, `Boundaries` (+ existing `Doorways`) |
| `AtlasDoorway` | `From`/`To` retyped `string`→`Position`; `FromCell`/`ToCell` removed. A connection plus two adjacent absolute cells |
| `Member` | `Room string` → `Position` |
| `MemberOutcome` | `Room` removed |
| `JoinInput` | `Room` removed |
| `SpawnInput` | `Room` removed (not on the wire — creation is the lobby's) |

**Sentinels: 34 → 35.** One added, none removed: `ErrNoCrossing` ("no doorway
joins those cells"). None are enumerated in the proto — they map to gRPC codes
in rpg-api per design rule 7 — but it drives a doc change, below.

**`EventKind`: unchanged, 13 values.** Including `TRAVERSED`, which outlived
the verb it was named for. The SDK is explicit about why: *one map does not
mean one narration* — a client renders a doorway differently from a corridor,
and collapsing it into `MOVED` would make a client re-derive it from geometry.
Its comment is rewritten; the enum is untouched.

## One thing the released SDK gets wrong, and what I did about it

**The v0.12.0 godoc contradicts the v0.12.0 code.** `MoveInput`'s doc comment
(`move.go:37`) says, in capitals, *"A WALK STILL DOES NOT CROSS A DOORWAY."*
The code 320 lines below it does exactly that — `doorwayBetween(atlas, here,
cell)` resolves the crossing, and `ErrNoCrossing` exists precisely to refuse
the case where no doorway joins two adjacent cells.

The stale paragraph is on `origin/main` too. The fix (*"a doc that stops
forbidding what it now allows"*) is sitting unmerged on
`feat/1048-walk-crosses-doorways`.

**I transcribed the code, not the doc.** Had I mirrored the prose, this
contract would tell every client author that walks cannot cross doorways —
exactly backwards, in the one place the release was about. Worth a heads-up to
the toolkit lane that the released doc is wrong.

## Adjacency is not permission

The corollary that earns its own callout in `MoveRequest` and `AtlasDoorway`:
two rooms may *touch* without a door, so a pair of cells can be perfectly
adjacent and still have nothing to walk through. That is invisible to a client
reading only `GetAtlasResponse.cells` — it is in `doorways` or it is nowhere.
A route planner must consult both, and the SDK keeps `ErrNoCrossing` distinct
from `ErrBrokenPath` (not adjacent at all) and `ErrBadPosition` (no cell
there): three different author mistakes, three different places to look.

## Breaking, and how the tags were handled

Breaking vs `main` by design — `breaking-change-approved` label applied per
`docs/how-to/breaking-change-workflow.md`.

**Retired fields are reserved by number, and by name where the name does not
come back.** I initially renumbered cleanly on the reasoning that a
one-day-old package with no deployed consumer does not need the ceremony.
`buf breaking` changed my mind, and the output is the argument: reusing tag 3
for a different type (`room:string` → `position:Position`) is the one proto
change that fails **silently** — old wire bytes get reinterpreted rather than
rejected. Every other break here is loud.

So changed fields moved to fresh tags with the old ones reserved. `doorways`
keeps tag 2 (same name, same type — genuinely unchanged), and `position` keeps
the tags it already had in `JoinRequest` (4) and `MemberOutcome` (3).
`AtlasDoorway` reuses the *names* `from`/`to` with a new type at fresh tags, so
those two names cannot be reserved; the four retired tags and the two names
that do not come back are.

**Result: the breaking surface went from 32 findings to 13, and same-tag type
changes went to zero.** All 13 remaining are clean deletions or the RPC
removal:

```
Previously present message "TraverseRequest" was deleted from file.
Previously present message "TraverseResponse" was deleted from file.
Previously present message "TraverseResponse.DiscoveredEntry" was deleted from file.
Previously present field "3" with name "room" on message "JoinRequest" was deleted.
Previously present field "1" with name "rooms" on message "GetAtlasResponse" was deleted.
Previously present RPC "Traverse" on service "SessionService" was deleted.
Previously present message "AtlasRoom" was deleted from file.
Previously present field "3" with name "room" on message "Member" was deleted.
Previously present field "2" with name "room" on message "MemberOutcome" was deleted.
Previously present field "2" with name "from" on message "AtlasDoorway" was deleted.
Previously present field "3" with name "from_cell" on message "AtlasDoorway" was deleted.
Previously present field "4" with name "to" on message "AtlasDoorway" was deleted.
Previously present field "5" with name "to_cell" on message "AtlasDoorway" was deleted.
```

## Provenance — read from the tag, never a checkout

This initiative has now been bitten twice by reading the toolkit's workspace
checkout, which sits on unmerged feature branches. It would have been bitten a
third time here: the checkout is on `feat/1048-walk-crosses-doorways` at
`5bc69e2`, **ahead of** the tag.

Both surfaces were therefore read from detached worktrees pinned to the tags,
verified before use:

```
v0.9.0  -> bee88e7   (tag points to bee88e7)   clean: 0 modified files
v0.12.0 -> fb0d704   (tag points to fb0d704)   clean: 0 modified files
```

`v0.12.0` confirmed an ancestor of the toolkit's `origin/main`.

## Verification

**Field-for-field, by script** — 37 message↔struct pairs compared field-by-field
in declaration order against the v0.12.0 godoc: **zero mismatches**. Unmapped Go
structs are the deliberate exclusions: `StartSessionInput/Output` and
`SpawnInput/Output` (design rule 5 — creation is the lobby's), `MonsterState`
(reachable only from `SpawnOutput`), and `Config`/`Manager`/`SessionData`/
`SaveError` (host-side types the SDK's laws keep in-process).

```
$ buf lint --disable-symlinks
(no output — clean)
$ buf format --diff --exit-code --disable-symlinks
(no output — clean)
$ buf breaking --disable-symlinks --against '...#branch=main'
13 findings, all intentional — listed above
$ buf generate --disable-symlinks     -> Go + TS, 13 RPCs
$ cd gen/go && go mod tidy && go build ./...
COMPILE-GO OK
$ npx tsc --noEmit --project tsconfig.json
TSC OK
$ make test-placement-facing-presence   PASS
$ make test-region-projection-presence  PASS
```

## Docs (same PR, per the how-to)

All five updated per `docs/how-to/add-a-new-service.md:98-109`. The component
doc needed real rewriting rather than a version bump — its "Traverse is
transitional" framing was the thing this change falsifies. It now carries the
three-release table, the adjacency-is-not-permission trap, and the Atlas
section. `data-model.md` records that the coordinate frame went from per-field
to uniformly absolute. `quality.md` notes that one of the three things holding
this service below an A is now resolved rather than scheduled.

## For the downstream lane

rpg-api's W2 (rpg-api#796) is in flight against the v0.9.0 shapes and absorbs
this reshape: the Traverse handler goes away, placements become cells, and the
Atlas projection changes shape. Flagging it here rather than leaving it to be
discovered at the version bump.

Closes #225

— director agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)
