### PR TITLE
feat(session): add GetWhere — a client can ask where it stands (session/v0.13.0)

### DIFF
--- a/dnd5e/api/session/v1alpha1/events.proto
+++ b/dnd5e/api/session/v1alpha1/events.proto
@@ -12,9 +12,9 @@ option java_package = "com.kirkdiggler.rpg.api.dnd5e.session.v1alpha1";
 // a string enum rather than free-form prose precisely because "it maps directly
 // onto a proto enum", and it is the field clients branch on.
 //
-// Read from session/v0.12.0. The vocabulary is UNCHANGED across v0.9.0 ->
-// v0.12.0 — all 13 kinds survive the one-map reshape, TRAVERSED included (see
-// below).
+// Read from session/v0.13.0. The vocabulary is UNCHANGED across v0.9.0 ->
+// v0.13.0 — all 13 kinds survive both the one-map reshape (TRAVERSED included,
+// see below) and the arrival of the Where read, which adds no beat.
 //
 // The vocabulary is OPEN TO GROWTH, which is a property of proto3 enums rather
 // than something this file has to build: an unrecognised number is PRESERVED on

--- a/dnd5e/api/session/v1alpha1/service.proto
+++ b/dnd5e/api/session/v1alpha1/service.proto
@@ -10,7 +10,7 @@ option java_multiple_files = true;
 option java_package = "com.kirkdiggler.rpg.api.dnd5e.session.v1alpha1";
 
 // SessionService is the wire form of the toolkit's `rulebooks/dnd5e/session`
-// package — one verb surface, transcribed (shapes read from session/v0.12.0).
+// package — one verb surface, transcribed (shapes read from session/v0.13.0).
 //
 // Three rules from rpg-project/ideas/session-api/design.md shape every message
 // below, and are worth reading before adding anything to this file:
@@ -389,6 +389,40 @@ message GetViewResponse {
   repeated Sighting sightings = 1;
 }
 
+// GetWhereRequest asks where one member stands.
+//
+// Added with session/v0.13.0 (toolkit#1051), and it closes design rule 11 on
+// the wire: a cold client can now learn its own position from a read. Before
+// this, a client knew its own cell only by remembering the last Move it made —
+// which holds right up until the moment it matters: a reconnect, a fresh tab, a
+// second device, a response it never received.
+//
+// NOT_FOUND if the session, encounter or member is absent.
+message GetWhereRequest {
+  string session = 1;
+  // The member whose own placement is being asked for.
+  string member = 2;
+}
+
+// GetWhereResponse mirrors session.WhereOutput.
+//
+// ONE MEMBER'S OWN PLACEMENT, and the singular is the design rather than a
+// first cut. There is deliberately no read that returns everybody's positions:
+// a roster would hand a client the cells of members it has never perceived —
+// around a corner, in a room it has not entered, behind a door it has not
+// opened — which is the one thing perception exists to prevent, and exactly the
+// fog-of-war leak design rule 4 keeps rpg-api away from. Where somebody ELSE
+// is, is GetView's answer, and GetView reports only what the observer holds.
+//
+// A LIVE READ, not a stored one: the position comes from the composition's
+// roster, which projects each member's cell when asked. A member who has walked
+// is reported where they are now.
+message GetWhereResponse {
+  // The cell they stand on, dungeon-absolute — the same coordinates the Atlas
+  // draws and every verb takes.
+  Position position = 1;
+}
+
 // GetAtlasRequest asks for a session's static world map.
 message GetAtlasRequest {
   string session = 1;
@@ -497,6 +531,11 @@ service SessionService {
 
   // GetView reports what one member currently perceives.
   rpc GetView(GetViewRequest) returns (GetViewResponse);
+
+  // GetWhere reports the cell one member stands on — the caller's own
+  // position, answerable cold. Deliberately singular; a roster read would leak
+  // the cells of members the client has never perceived.
+  rpc GetWhere(GetWhereRequest) returns (GetWhereResponse);
 
   // GetAtlas returns the static world map. Construction truth; cache per
   // encounter.

--- a/dnd5e/api/session/v1alpha1/service.proto
+++ b/dnd5e/api/session/v1alpha1/service.proto
@@ -381,10 +381,15 @@ message GetViewRequest {
 
 // GetViewResponse carries session.View's return slice.
 //
-// A cold client cannot yet learn its OWN position from this: View reports what a
-// member perceives and skips self. That gap is SDK-first work (design rule 11,
-// toolkit#933) and explicitly not a gate on this package — until it lands,
-// reconnect leans on GetStory replay.
+// WHAT THIS MEMBER PERCEIVES OF OTHERS. It skips self, and that is a division of
+// labour rather than a gap: GetWhere answers "where am I" (session/v0.13.0),
+// and GetView answers "what do I hold of everyone else" — reporting only what
+// the observer actually perceives, which is what keeps it from leaking the
+// cells of members behind a door they have not opened.
+//
+// Through session/v0.12.0 the omission WAS a gap, because nothing else answered
+// self either; design rule 11 tracked it and reconnect leaned on GetStory
+// replay for position. That is closed — see GetWhereRequest below.
 message GetViewResponse {
   repeated Sighting sightings = 1;
 }

--- a/dnd5e/api/session/v1alpha1/types.proto
+++ b/dnd5e/api/session/v1alpha1/types.proto
@@ -7,7 +7,7 @@ option java_multiple_files = true;
 option java_package = "com.kirkdiggler.rpg.api.dnd5e.session.v1alpha1";
 
 // This package transcribes the exported surface of the toolkit's
-// `rulebooks/dnd5e/session` package (read from session/v0.12.0). Every message
+// `rulebooks/dnd5e/session` package (read from session/v0.13.0). Every message
 // here mirrors an SDK type field-for-field: rpg-api invents no vocabulary, and
 // a field with no SDK counterpart is a design change that goes through
 // rpg-project/ideas/session-api/design.md first (rule 1).

--- a/docs/architecture/components/session-service.md
+++ b/docs/architecture/components/session-service.md
@@ -2,7 +2,7 @@
 name: SessionService
 description: D&D 5e session contract (v1alpha1) — the wire transcription of the toolkit's session package; one map, no rooms on the seam; the surface that replaces the v1alpha2 encounter stack
 updated: 2026-08-16
-confidence: high — proto-side only; no consumer yet, verified by scripted field-for-field comparison against rulebooks/dnd5e/session v0.12.0 read from the tag
+confidence: high — proto-side only; no consumer yet, verified by scripted field-for-field comparison against rulebooks/dnd5e/session v0.13.0 read from the tag
 ---
 
 # SessionService
@@ -14,8 +14,9 @@ Package `dnd5e.api.session.v1alpha1`.
 
 Design doc: `rpg-project/ideas/session-api/design.md`. Umbrella:
 `KirkDiggler/rpg-project#227`. Landed by rpg-api-protos#222 (issue #221) against
-session/v0.9.0, then re-transcribed by #226 (issue #225) against
-**session/v0.12.0**, which is the version this doc describes.
+session/v0.9.0, re-transcribed by #226 (issue #225) against
+**session/v0.12.0**, and extended by #228 (issue #227) with `GetWhere` at
+**session/v0.13.0**, which is the version this doc describes.
 
 ## What makes this service different from every other one here
 
@@ -56,6 +57,7 @@ seam's **state**, delivered across three toolkit releases:
 | `session/v0.10.0` | the Atlas became one map — no per-room decomposition, one grid for the field, cells sorted by coordinate |
 | `session/v0.11.0` | joins, placements and outcomes went roomless — `Member` trades its room ID for an absolute `position` |
 | `session/v0.12.0` | a walk crosses a doorway; the `Traverse` verb retires |
+| `session/v0.13.0` | a client can ask where it stands — the `Where` read arrives (purely additive) |
 
 Consequences for this contract, all live:
 
@@ -68,7 +70,7 @@ Consequences for this contract, all live:
 
 ## RPCs
 
-Thirteen, mirroring the SDK verbs one-for-one.
+Fourteen, mirroring the SDK verbs one-for-one.
 
 | RPC | SDK verb | Request:Response | Notes |
 |---|---|---|---|
@@ -82,7 +84,8 @@ Thirteen, mirroring the SDK verbs one-for-one.
 | `End` | `End` | `EndRequest:EndResponse` | Declared external endings only — `NotFound` means the key was never on the menu |
 | `GetStatus` | `Status` | `GetStatusRequest:GetStatusResponse` | Encounter-wide, never per-member |
 | `GetStory` | `Story` | `GetStoryRequest:GetStoryResponse` | The resync source of truth |
-| `GetView` | `View` | `GetViewRequest:GetViewResponse` | Sightings. Skips self — see the known gap below |
+| `GetView` | `View` | `GetViewRequest:GetViewResponse` | Sightings — what this member perceives of *others*. Skips self by design; `GetWhere` answers self |
+| `GetWhere` | `Where` | `GetWhereRequest:GetWhereResponse` | The caller's own cell, answerable cold. Deliberately singular — no roster read exists |
 | `GetAtlas` | `Atlas` | `GetAtlasRequest:GetAtlasResponse` | Static; cache per encounter, never per frame |
 | `StreamEvents` | `EventStream` | `StreamEventsRequest:stream Event` | Per-recipient projections |
 
@@ -107,6 +110,14 @@ The SDK gives that refusal its own sentinel (`ErrNoCrossing`, *"no doorway
 joins those cells"*), kept deliberately distinct from `ErrBrokenPath` (the two
 cells are not adjacent at all) and `ErrBadPosition` (there is no cell there).
 Three different author mistakes, three different places to look.
+
+> **Do not trust the SDK's `MoveInput` godoc here.** It still carries a
+> paragraph reading *"A WALK STILL DOES NOT CROSS A DOORWAY"* — stale since
+> v0.12.0, contradicted by its own code ~320 lines below, and **still present at
+> v0.13.0**. Filed as rpg-toolkit#1052; the fix is sitting on an unmerged
+> branch. This contract is transcribed from the code, which crosses. If you are
+> reading the SDK to check this page, read `move.go`'s validation, not its
+> comment.
 
 ## The Atlas
 
@@ -190,15 +201,37 @@ re-derive it from the geometry.
   automatically — never as a second RPC. The SDK seals its `DissolveCause`
   interface with an unexported method to make that structural.
 
+## Reconnect, and the gap that closed
+
+Design rule 11 asked that a cold client be able to learn its own position from
+reads alone. Through v0.12.0 it could not: `GetView` reports what a member
+perceives and *skips self*, `GetStatus` is encounter-wide, and while `Member`
+gained an absolute position at v0.11.0, no read returned a `Member`. A client
+knew its own cell only by remembering the last `Move` it made — which holds
+right up until the moment it matters: a reconnect, a fresh tab, a second
+device, a response it never received.
+
+**`session/v0.13.0` closed it, and `GetWhere` is that read on the wire.** A
+cold client's reconnect is now three reads with no replay dependency for
+position:
+
+1. `GetWhere` — where am I
+2. `GetAtlas` — what does the map look like (cache it; construction truth)
+3. `GetStory` — what did I miss, from my last known `seq`
+
+`GetStory` still matters, because story replay is how a client recovers *events*
+it missed. What changed is that position is no longer derived from it.
+
+**Why there is no roster read**, and this is the part worth not "improving"
+later: a read returning everybody's positions would hand a client the cells of
+members it has never perceived — around a corner, in a room it has not entered,
+behind a door it has not opened. That is precisely the fog-of-war leak design
+rule 4 exists to prevent. Where somebody *else* is, is `GetView`'s answer, and
+`GetView` reports only what the observer actually holds. The singular shape of
+`GetWhere` is the design, not a first cut.
+
 ## Known gaps, inherited and stated rather than papered over
 
-- **A cold client still cannot learn its own position from a read.** This
-  narrowed at v0.11.0 without closing: `Member` now carries an absolute
-  `position`, so a `Join` tells you where you are — but no *read* returns a
-  `Member`. `GetView` reports what a member perceives and skips self;
-  `GetStatus` is encounter-wide. So a client that reconnects still leans on
-  `GetStory` replay. The fix is SDK-first (design rule 11, rpg-toolkit#933) and
-  is explicitly not a gate on this package.
 - **`Attack` is character-attackers-only, and nothing spends.** Both are the
   SDK's stated scope — a monster's action can declare a save gate the seam has
   no vocabulary for, and the economy that would spend an action sits above this

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -50,8 +50,8 @@ rpg-api-protos/
     events.proto                 # LobbyEvent stream — snapshot + membership/presence deltas
   dnd5e/api/authoring/v1alpha1/  # own subpackage; dev-gated dungeon authoring (Dungeon Builder arc, rpg-project#169)
     service.proto                # AuthoringService — PutDungeon; not yet consumed (rpg-api S1 pending)
-  dnd5e/api/session/v1alpha1/    # service-first layout; field-for-field transcription of rpg-toolkit rulebooks/dnd5e/session @ v0.12.0 — one map, no room IDs on the seam (rpg-project#227)
-    service.proto                # SessionService — 13 RPCs mirroring the SDK verbs (no Traverse: a walk crosses a doorway); not yet consumed (rpg-api W2 in flight)
+  dnd5e/api/session/v1alpha1/    # service-first layout; field-for-field transcription of rpg-toolkit rulebooks/dnd5e/session @ v0.13.0 — one map, no room IDs on the seam (rpg-project#227)
+    service.proto                # SessionService — 14 RPCs mirroring the SDK verbs (no Traverse: a walk crosses a doorway; GetWhere answers "where am I"); not yet consumed (rpg-api W2 in flight)
     types.proto                  # Position (double x/y, mirrors spatial.Position), Member, CharacterState, Sighting, AtlasDoorway/Boundary, SaveReport, ...
     events.proto                 # Event stream — flat per-recipient envelope + EventKind; no snapshot, GetStory is the resync path
   sandbox/api/v1alpha1/

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -212,7 +212,9 @@ Re-grade once the rpg-api PR lands.
 Landed 2026-08-16 (rpg-api-protos#222) against `session/v0.9.0`, re-transcribed
 the same day against `session/v0.12.0` (#226, issue #225) after Kirk ruled the
 contract should track the latest SDK rather than the version it was first
-written from. No consumer yet — same "consumer PR
+written from, then extended to `session/v0.13.0` with `GetWhere` (#228, issue
+#227) — three SDK versions tracked in one day, each within hours of the tag.
+No consumer yet — same "consumer PR
 pending, not speculative" exception as the two above: `rpg-api` (W2) and
 `rpg-dnd5e-web` (W3) are the queued next legs of `rpg-project#227`.
 
@@ -248,9 +250,19 @@ same pass took room IDs off the seam entirely, so the per-field coordinate frame
 (absolute in the Atlas, room-scoped in placements) that a client could plausibly
 have confused is gone too.
 
-That re-transcription is also the first evidence this contract tracks its source
-rather than drifting from it, which is the property the whole transcription
-argument rests on.
+**And the v0.13.0 pass removed a second.** Design rule 11 — a cold client can
+learn its own position from reads alone — was listed as an open gap through
+v0.12.0. `GetWhere` closes it on the wire: reconnect is now `GetWhere` +
+`GetAtlas` + `GetStory` rather than story replay carrying position. The shape is
+also right rather than merely present — singular by design, because a roster
+read would leak the cells of members a client has never perceived, which is the
+fog-of-war failure the whole visibility rule exists to prevent.
+
+Those two passes together are the strongest evidence this contract tracks its
+source rather than drifting from it, which is the property the entire
+transcription argument rests on. Three SDK versions in one day, each transcribed
+from the tag and machine-verified, with the surface diff computed rather than
+assumed.
 
 Still held below A by: no runtime validation this shape survives an orchestrator
 yet, and the minted third `Position`, which is correct here but is still a name

--- a/docs/status.md
+++ b/docs/status.md
@@ -16,6 +16,18 @@ shape and consumer drift, it shows up here as a "rough edge."
 
 ## Active work
 
+- **Session contract: `GetWhere` at `session/v0.13.0` (rpg-api-protos#228,
+  issue #227, 2026-08-16)** — purely additive, `buf breaking` green, no label.
+  Adds `rpc GetWhere(GetWhereRequest) returns (GetWhereResponse)` mirroring the
+  SDK's `Where` verb: the caller's own cell in dungeon-absolute space.
+  **This closes design rule 11 on the wire** — a cold client can learn its own
+  position from a read, so reconnect is `GetWhere` + `GetAtlas` + `GetStory`
+  rather than story replay carrying position. Deliberately singular: there is
+  no roster-of-positions read, because one would leak the cells of members a
+  client has never perceived. The v0.12.0 -> v0.13.0 surface diff was verified
+  in full and is additive-only — two new types, zero field changes on existing
+  ones, sentinels unchanged at 35, all enums unchanged. 14 RPCs.
+
 - **Session contract re-transcribed against `session/v0.12.0`
   (rpg-api-protos#226, issue #225, W1 of the API session integration,
   2026-08-16)** — the
@@ -302,7 +314,7 @@ Your read of where we are. See [quality.md](quality.md) for grade + rationale.
 | `dnd5e.CharacterService` | Medium-high — the biggest service by RPC count (~25 RPCs); coherent draft + finalize flow; deprecated proficiency fields still present |
 | `api.DiceService` | High — small (3 RPCs), consumed by rpg-api, well-shaped |
 | `dnd5e.authoring.AuthoringService` | High (contract) / no consumer yet — new (rpg-api-protos#200, 2026-07-30), 1 focused RPC, gate-passed for shape and error-transport clarity; a consumer (rpg-api S1) is queued in the same arc, distinct from the Low-rated services below which have none in flight |
-| `dnd5e.session.SessionService` | High (contract) / no consumer yet — new (rpg-api-protos#222, re-transcribed against session/v0.12.0 in #226, 2026-08-16). Confidence is unusually cheap here: the shapes were not designed, they were transcribed from a shipped SDK and machine-checked against it, so "is this the right shape?" reduces to a question the toolkit already answered. What is genuinely unverified is the same thing every pre-consumer service has — that it survives contact with an orchestrator (rpg-api W2, queued) |
+| `dnd5e.session.SessionService` | High (contract) / no consumer yet — new (rpg-api-protos#222, re-transcribed against session/v0.12.0 in #226, `GetWhere` added at v0.13.0 in #228, 2026-08-16). Confidence is unusually cheap here: the shapes were not designed, they were transcribed from a shipped SDK and machine-checked against it, so "is this the right shape?" reduces to a question the toolkit already answered. What is genuinely unverified is the same thing every pre-consumer service has — that it survives contact with an orchestrator (rpg-api W2, queued) |
 | `api.EnvironmentService` | Low — defined, not consumed. Generic room shape duplicates encounter Room |
 | `api.SpatialService` | Low — defined, not consumed |
 | `api.SpawnService` | Low — defined, not consumed |


### PR DESCRIPTION
Adds `rpc GetWhere(GetWhereRequest) returns (GetWhereResponse)` to
`SessionService`, mirroring the `Where` verb added in
**`rulebooks/dnd5e/session/v0.13.0`** (toolkit#1051, *"a client can ask where
it stands"*). W1 of the API session integration (rpg-project#227); design:
`rpg-project/ideas/session-api/design.md` §1–§2, rule 11.

**Purely additive** — `buf breaking` is green and no
`breaking-change-approved` label is needed.

```proto
rpc GetWhere(GetWhereRequest) returns (GetWhereResponse);

message GetWhereRequest {
  string session = 1;
  string member = 2;
}

message GetWhereResponse {
  Position position = 1;
}
```

Mirrors `Where(WhereInput{Session, Member}) → WhereOutput{Position}` — the
caller's own cell in dungeon-absolute space. Slotted between `GetView` and
`GetAtlas` to match the design's RPC table. 13 RPCs → **14**.

## It closes design rule 11 on the wire

Rule 11 asked that a cold client be able to learn its own position from reads
alone. Through v0.12.0 it could not, and the reasons compounded: `GetView`
reports what a member perceives and **skips self**; `GetStatus` is
encounter-wide by design and must never learn anything per-member; and although
`Member` gained an absolute position at v0.11.0, **no read returns a `Member`**.

So a client knew its own cell only by remembering the last `Move` it made — which
holds right up until the moment it matters: a reconnect, a fresh tab, a second
device, a response it never received.

Reconnect is now three reads:

1. `GetWhere` — where am I
2. `GetAtlas` — what the map looks like (construction truth; cache per encounter)
3. `GetStory` — what I missed, from my last known `seq`

`GetStory` still matters — story replay is how a client recovers missed *events*.
What changed is that position is no longer derived from it.

## Why it is singular, and should stay that way

There is deliberately **no roster-of-positions read**, and this is the part
worth not "improving" later. A read returning everybody's positions would hand a
client the cells of members it has never perceived — around a corner, in a room
it has not entered, behind a door it has not opened. That is exactly the
fog-of-war leak design rule 4 keeps rpg-api away from.

Where somebody *else* is, is `GetView`'s answer, and `GetView` reports only what
the observer actually holds. The SDK makes the same point in its own verb doc;
the proto comment carries it so the next person to want a batch read finds the
reasoning before writing it.

## v0.12.0 → v0.13.0: verified additive, not assumed

The release is described as additive, so I diffed the whole exported surface
rather than trusting the label:

| | result |
|---|---|
| **Added types** | `WhereInput{Session, Member}`, `WhereOutput{Position}` |
| **Removed types** | none |
| **Field changes on existing types** | **none** |
| **Verbs** | `Where` added; none removed |
| **Sentinels** | 35 → 35 — none added, none removed |
| **`EventKind`** | unchanged, 13 values |
| **`ClockKind` / `GridKind` / `MemberKind`** | unchanged |

Zero non-`Where` drift, confirmed.

## Provenance — read from the tag, never the checkout

Both surfaces read from detached worktrees pinned to their tags and verified
clean before use. The toolkit checkout is not a safe source and this initiative
has been bitten by it twice:

```
v0.12.0 -> fb0d704   (tag: fb0d704)   clean: 0 modified files
v0.13.0 -> 94a298a   (tag: 94a298a)   clean: 0 modified files
```

`v0.13.0` confirmed an ancestor of the toolkit's `origin/main`.

## The stale SDK doc is still there

rpg-toolkit#1052 — `MoveInput`'s godoc still reads *"A WALK STILL DOES NOT
CROSS A DOORWAY"*, contradicted by its own code ~320 lines below — **is still
present at v0.13.0**. I re-checked rather than assuming the follow-up had
landed: the paragraph is at `move.go:37` and `doorwayBetween` still has three
call sites resolving crossings.

This contract continues to transcribe the code. The component doc now carries a
blockquote warning any reader who goes to the SDK to check this page: read
`move.go`'s validation, not its comment.

## Verification

**Field-for-field, by script — 39 message↔struct pairs against the v0.13.0
godoc, zero mismatches**, including the two new `Where` pairs. Unmapped Go
structs are the usual deliberate exclusions (`StartSession*`/`Spawn*` per rule
5, `MonsterState` reachable only from `SpawnOutput`, and the host-side
`Config`/`Manager`/`SessionData`/`SaveError`).

```
$ buf lint --disable-symlinks                          (no output — clean)
$ buf format --diff --exit-code --disable-symlinks     (no output — clean)
$ buf breaking --disable-symlinks --against '...#branch=main'
(no output — clean; purely additive)
$ buf generate --disable-symlinks                      Go + TS, 14 RPCs
$ cd gen/go && go mod tidy && go build ./...           COMPILE-GO OK
$ npx tsc --noEmit --project tsconfig.json             TSC OK
$ make test-placement-facing-presence                  PASS
$ make test-region-projection-presence                 PASS
```

## Docs

Updated per `docs/how-to/add-a-new-service.md:98-109`. `data-model.md` is
deliberately untouched — that item is conditional on introducing new shared
types, and `GetWhere` reuses `Position`.

The component doc's **"Known gaps"** section had to change rather than grow: it
asserted that a cold client still cannot learn its own position, which this PR
makes false. That gap is deleted and replaced with a **Reconnect** section
covering the three-read sequence and the no-roster-read reasoning. `quality.md`
records that a second of the three things holding this service below an A is now
resolved.

Closes #227

— director agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)
