### PR TITLE
feat(session): HexLayout on GetAtlasResponse — the atlas says which way its hexes point (session/v0.20.0)

### DIFF
--- a/dnd5e/api/session/v1alpha1/service.proto
+++ b/dnd5e/api/session/v1alpha1/service.proto
@@ -452,6 +452,13 @@ message GetAtlasResponse {
 
   // The coordinate family the whole map speaks. One value, not one per room.
   GridKind grid = 3;
+  // How to lay the cells out to draw them. Set exactly when `grid` is
+  // GRID_KIND_HEX and UNSPECIFIED otherwise — the composition's own law (a hex
+  // field must declare an orientation, a square field must not) mirrored at
+  // the wire. Not a default: a square map that said pointy-top would be a
+  // client believing something that cannot be true about its grid. See
+  // HexLayout for why this is a separate word from the authoring orientation.
+  HexLayout layout = 8;
   // occluders = 5 held a repeated Position — the subset of `cells` that blocked
   // line of sight, as bare coordinates — until session/v0.18.0 replaced it with
   // `props` below (rpg-toolkit#1130). A NEW TAG rather than a retype of 5, on

--- a/dnd5e/api/session/v1alpha1/types.proto
+++ b/dnd5e/api/session/v1alpha1/types.proto
@@ -99,6 +99,30 @@ enum GridKind {
   GRID_KIND_HEX = 2;
 }
 
+// HexLayout names which way a hex map's cells point when drawn. Mirrors
+// session.HexLayout ("pointy_top" / "flat_top"), which arrived at
+// session/v0.20.0 (rpg-toolkit#1140, ADR-0040).
+//
+// THE ONE FACT A CLIENT CANNOT RECOVER FROM THE CELLS. Axial coordinates fix
+// the topology — the same six neighbours either way — and not the picture: the
+// same cell set laid out pointy-top and flat-top gives two different images,
+// roughly one rotated from the other. The first client to draw the reference
+// tomb guessed from the content and got a diagonal staircase.
+//
+// This is the RENDER word, deliberately not the authoring word. The toolkit's
+// composition holds an Orientation — the frame an author typed offset cells
+// in — which the session seam consumes when it enumerates the cells and never
+// hands out. Same two values, a different question, and the staircase happened
+// because the two questions shared a word. Do not infer this from anything
+// else on the wire; read it.
+enum HexLayout {
+  HEX_LAYOUT_UNSPECIFIED = 0;
+  // A vertex up: rows run straight and alternate rows stagger.
+  HEX_LAYOUT_POINTY_TOP = 1;
+  // An edge up: columns run straight and alternate columns stagger.
+  HEX_LAYOUT_FLAT_TOP = 2;
+}
+
 // MemberKind categorises a member. Mirrors session.MemberKind
 // ("player" / "monster").
 enum MemberKind {

--- a/docs/architecture/components/session-service.md
+++ b/docs/architecture/components/session-service.md
@@ -1,8 +1,8 @@
 ---
 name: SessionService
 description: D&D 5e session contract (v1alpha1) — the wire transcription of the toolkit's session package; one map, no rooms on the seam; the surface that replaces the v1alpha2 encounter stack
-updated: 2026-08-20
-confidence: high — proto-side only; no consumer yet, verified by scripted field-for-field comparison against rulebooks/dnd5e/session v0.18.0 read from the tag
+updated: 2026-08-21
+confidence: high — verified by scripted field-for-field comparison against rulebooks/dnd5e/session v0.18.0 read from the tag, plus the v0.20.0 `Atlas.Layout` delta read from rpg-toolkit#1147; first live consumer is rpg-dnd5e-web's Concepts Lab (rpg-dnd5e-web#759)
 ---
 
 # SessionService
@@ -16,8 +16,9 @@ Design doc: `rpg-project/ideas/session-api/design.md`. Umbrella:
 `KirkDiggler/rpg-project#227`. Landed by rpg-api-protos#222 (issue #221) against
 session/v0.9.0, re-transcribed by #226 (issue #225) against
 **session/v0.12.0**, extended by #228 (issue #227) with `GetWhere` at
-**session/v0.13.0**, and caught up to **session/v0.18.0** — the version this
-doc describes — by the delta below.
+**session/v0.13.0**, caught up to **session/v0.18.0** by the delta below, and
+extended to **session/v0.20.0** — the version this doc describes — with
+`GetAtlasResponse.layout` (rpg-toolkit#1140).
 
 ## What makes this service different from every other one here
 
@@ -65,6 +66,8 @@ seam's **state**, delivered across three toolkit releases:
 | `session/v0.17.0` | **a second swing costs something** — the action economy starts refusing (rpg-toolkit#1097) |
 | `session/v0.17.1` | the walk speaks only absolute positions (rpg-toolkit#1059) |
 | `session/v0.18.0` | **the new Atlas** — props that say what they are, replacing bare occluder coordinates (rpg-toolkit#1130) |
+| `session/v0.19.0` | the hex-orientation correction lands (rpg-toolkit#1141/#1143/#1145) — no contract change; every served cell of a hex map moves |
+| `session/v0.20.0` | **the atlas says which way its hexes point** — `Atlas.Layout` (rpg-toolkit#1140, ADR-0040) |
 
 Consequences for this contract, all live:
 
@@ -136,8 +139,27 @@ walk case joins it and nothing on this contract has to change.
 ## The Atlas
 
 `GetAtlasResponse` is the whole map in one piece: one `grid` for the field,
-every `cell` sorted by coordinate, every `prop` standing on it, every
-`boundary`, and every `doorway` as a crossable cell pair.
+which way its hexes point (`layout`), every `cell` sorted by coordinate, every
+`prop` standing on it, every `boundary`, and every `doorway` as a crossable
+cell pair.
+
+**`layout` arrived at v0.20.0 (tag 8)**, and it exists because a client drew the
+reference tomb as a diagonal staircase. Axial coordinates fix the topology —
+the same six neighbours either way — and not the picture: the same cell set
+laid out pointy-top and flat-top gives two different images. Nothing on the
+wire said which, and the guess that looked right was wrong, because
+`tools/spatial` had the two orientations running each other's offset schemes
+(rpg-toolkit#1140 → #1141/#1143/#1145). With that corrected, the honest answer
+is finally the authored one — and now the wire says it.
+
+It is the **render** word, deliberately not the authoring word. The toolkit's
+composition keeps `Orientation` — the frame an author typed offset cells in —
+and the session seam consumes it when it enumerates the cells, never handing
+it out. `layout` is what a client does with the cells it receives. Same two
+values, a different question, and a different name so they cannot be confused
+again (ADR-0040). Present exactly when `grid` is `HEX`; `UNSPECIFIED` on a
+square map, which has no such thing. **Read it; do not infer it** — not from
+the cells, not from the YAML, not from a bounding box.
 
 **`props` replaced `occluders` at v0.18.0**, and the reason generalises past
 this field. `occluders` was the subset of cells that blocked sight, carried as


### PR DESCRIPTION
Wire half of rpg-toolkit#1140. Mirrors `session.Atlas.Layout` from rpg-toolkit#1147 (merged; `session/v0.20.0`), decision in toolkit ADR-0040.

## What

- `types.proto`: `enum HexLayout { UNSPECIFIED, POINTY_TOP, FLAT_TOP }` — mirrors `session.HexLayout` (`"pointy_top"` / `"flat_top"`).
- `service.proto`: `GetAtlasResponse.layout = 8`. Set exactly when `grid` is `HEX`, `UNSPECIFIED` on square. New tag, nothing reserved or retyped.
- `docs/architecture/components/session-service.md`: version table rows for v0.19.0 (orientation correction, no contract change) and v0.20.0, and an Atlas paragraph on why this field exists and why it is a *separate word* from the authoring orientation.

## Why a separate word

A client could not draw a hex atlas from the wire: axial cells fix the topology and not the picture, and the first one to render the reference tomb guessed from the content and got a diagonal staircase. The toolkit's composition keeps `Orientation` (the frame an author typed in); this is `layout` (what a client draws with). Same two values, a different question — and the staircase happened because the two questions shared one word.

## Evidence

- `buf format -w` — no diff beyond the edit; `buf lint` — clean; `buf breaking --against .git#branch=main` — clean (additive).
- Per this repo's rule, no bespoke tests re-testing generated mechanics; the generate/compile gates cover it.

## Downstream

rpg-api: translate `session.HexLayout` → `HexLayout` (pure mapping), bump the session pin to v0.20.0, and move the `internal/sessionworld` start literal that shifted with the orientation fix. Then rpg-dnd5e-web replaces its hardcoded `DEFAULT_LAYOUT = 'flat'` — pinned to the *bug's* answer — with this field and recaptures the tomb fixture.

— asset-pipeline agent, on behalf of KirkDiggler
